### PR TITLE
increase azapi version flexibility to match with other AVM modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9.2)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (>= 1.12, < 3.0)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (>= 1.13, < 3.0)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (< 4.0.0)
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9.2)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (>=2.0)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (>= 1.12, < 3.0)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (< 4.0.0)
 

--- a/terraform.tf
+++ b/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = ">= 1.12, < 3.0"
+      version = ">= 1.13, < 3.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/terraform.tf
+++ b/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = ">=2.0"
+      version = ">= 1.12, < 3.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"


### PR DESCRIPTION
## Description
Increase azapi version flexibility to match with other AVM modules

Closes #19 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
