### PR TITLE
fix: incorrect use of `aci_connector_linux_subnet_name` variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -145,7 +145,7 @@ resource "azurerm_kubernetes_cluster" "this" {
     for_each = var.aci_connector_linux_subnet_name != null ? [var.aci_connector_linux_subnet_name] : []
 
     content {
-      subnet_name = aci_connector_linux.value.subnet_name
+      subnet_name = aci_connector_linux.value
     }
   }
   dynamic "api_server_access_profile" {


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->
Fixes #23

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [X] Azure Verified Module updates:
  - [X] Bugfix containing backwards compatible bug fixes
    - [X] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [X] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
