### PR TITLE
Add new conditional output to expose kube_admin_config attrubute

### DIFF
--- a/README.md
+++ b/README.md
@@ -1193,6 +1193,10 @@ The following outputs are exported:
 
 Description: The object ID of the key vault secrets provider.
 
+### <a name="output_kube_admin_config"></a> [kube\_admin\_config](#output\_kube\_admin\_config)
+
+Description: The kube\_admin\_config block of the AKS cluster, only available when Local Accounts & Role-Based Access Control (RBAC) with AAD are enabled.
+
 ### <a name="output_kubelet_identity_id"></a> [kubelet\_identity\_id](#output\_kubelet\_identity\_id)
 
 Description: The identity ID of the kubelet identity.

--- a/main.tf
+++ b/main.tf
@@ -420,9 +420,9 @@ resource "azurerm_kubernetes_cluster" "this" {
 
     content {
       mode                             = service_mesh_profile.value.mode
+      revisions                        = service_mesh_profile.value.revisions
       external_ingress_gateway_enabled = service_mesh_profile.value.external_ingress_gateway_enabled
       internal_ingress_gateway_enabled = service_mesh_profile.value.internal_ingress_gateway_enabled
-      revisions                        = service_mesh_profile.value.revisions
 
       dynamic "certificate_authority" {
         for_each = service_mesh_profile.value.certificate_authority != null ? [service_mesh_profile.value.certificate_authority] : []
@@ -477,8 +477,8 @@ resource "azurerm_kubernetes_cluster" "this" {
     for_each = var.windows_profile != null ? [var.windows_profile] : []
 
     content {
-      admin_username = windows_profile.value.admin_username
       admin_password = var.windows_profile_password
+      admin_username = windows_profile.value.admin_username
       license        = windows_profile.value.license
 
       dynamic "gmsa" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,15 @@ output "key_vault_secrets_provider_object_id" {
   value       = try(azurerm_kubernetes_cluster.this.key_vault_secrets_provider[0].secret_identity[0].object_id, null)
 }
 
+output "kube_admin_config" {
+  description = "The kube_admin_config block of the AKS cluster, only available when Local Accounts & Role-Based Access Control (RBAC) with AAD are enabled."
+  sensitive   = true
+  value = (
+    lookup(var.azure_active_directory_role_based_access_control, "azure_rbac_enabled", false) == true &&
+    !var.local_account_disabled ? azurerm_kubernetes_cluster.this.kube_admin_config : null
+  )
+}
+
 output "kubelet_identity_id" {
   description = "The identity ID of the kubelet identity."
   value       = azurerm_kubernetes_cluster.this.kubelet_identity[0].object_id
@@ -42,13 +51,4 @@ output "private_endpoints" {
 output "resource_id" {
   description = "Resource ID of the Kubernetes cluster."
   value       = azurerm_kubernetes_cluster.this.id
-}
-
-output "kube_admin_config" {
-  value = (
-    lookup(var.azure_active_directory_role_based_access_control, "azure_rbac_enabled", false) == true &&
-    !var.local_account_disabled ? azurerm_kubernetes_cluster.this.kube_admin_config : null
-  )
-  description = "The kube_admin_config block of the AKS cluster, only available when Local Accounts & Role-Based Access Control (RBAC) with AAD are enabled."
-  sensitive   = true
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -43,3 +43,12 @@ output "resource_id" {
   description = "Resource ID of the Kubernetes cluster."
   value       = azurerm_kubernetes_cluster.this.id
 }
+
+output "kube_admin_config" {
+  value = (
+    lookup(var.azure_active_directory_role_based_access_control, "azure_rbac_enabled", false) == true &&
+    !var.local_account_disabled ? azurerm_kubernetes_cluster.this.kube_admin_config : null
+  )
+  description = "The kube_admin_config block of the AKS cluster, only available when Local Accounts & Role-Based Access Control (RBAC) with AAD are enabled."
+  sensitive   = true
+}


### PR DESCRIPTION
## Description
Add new conditional output to expose kube_admin_config attrubute.
Output conditional aligned to match conditions the cluster resource generates the output.
<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
