### PR TITLE
[Feature] Add new conditional output to expose kube_admin_config attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -1193,6 +1193,10 @@ The following outputs are exported:
 
 Description: The object ID of the key vault secrets provider.
 
+### <a name="output_kube_admin_config"></a> [kube\_admin\_config](#output\_kube\_admin\_config)
+
+Description: The kube\_admin\_config block of the AKS cluster, only available when Local Accounts & Role-Based Access Control (RBAC) with AAD are enabled.
+
 ### <a name="output_kubelet_identity_id"></a> [kubelet\_identity\_id](#output\_kubelet\_identity\_id)
 
 Description: The identity ID of the kubelet identity.

--- a/locals.tf
+++ b/locals.tf
@@ -3,7 +3,8 @@ locals {
     (contains(["patch"], var.automatic_upgrade_channel) && can(regex("^[0-9]{1,}\\.[0-9]{1,}$", var.kubernetes_version)) && (can(regex("^[0-9]{1,}\\.[0-9]{1,}$", var.default_node_pool.orchestrator_version)) || var.default_node_pool.orchestrator_version == null)) ||
     (contains(["rapid", "stable", "node-image"], var.automatic_upgrade_channel) && var.kubernetes_version == null && var.default_node_pool.orchestrator_version == null)
   )
-  dns_prefix = coalesce(var.dns_prefix, random_string.dns_prefix.result)
+  dns_prefix         = coalesce(var.dns_prefix, random_string.dns_prefix.result)
+  kube_admin_enabled = !var.local_account_disabled && var.azure_active_directory_role_based_access_control != null && lookup(var.azure_active_directory_role_based_access_control, "azure_rbac_enabled", false)
   managed_identities = {
     system_assigned_user_assigned = (var.managed_identities.system_assigned || length(var.managed_identities.user_assigned_resource_ids) > 0) ? {
       this = {

--- a/locals.tf
+++ b/locals.tf
@@ -3,8 +3,15 @@ locals {
     (contains(["patch"], var.automatic_upgrade_channel) && can(regex("^[0-9]{1,}\\.[0-9]{1,}$", var.kubernetes_version)) && (can(regex("^[0-9]{1,}\\.[0-9]{1,}$", var.default_node_pool.orchestrator_version)) || var.default_node_pool.orchestrator_version == null)) ||
     (contains(["rapid", "stable", "node-image"], var.automatic_upgrade_channel) && var.kubernetes_version == null && var.default_node_pool.orchestrator_version == null)
   )
-  dns_prefix         = coalesce(var.dns_prefix, random_string.dns_prefix.result)
-  kube_admin_enabled = !var.local_account_disabled && var.azure_active_directory_role_based_access_control != null && lookup(var.azure_active_directory_role_based_access_control, "azure_rbac_enabled", false)
+  dns_prefix = coalesce(var.dns_prefix, random_string.dns_prefix.result)
+  kube_admin_enabled = (
+    !var.local_account_disabled
+    ? (
+      var.azure_active_directory_role_based_access_control != null &&
+      try(lookup(var.azure_active_directory_role_based_access_control, "azure_rbac_enabled", false), false)
+    )
+    : false
+  )
   managed_identities = {
     system_assigned_user_assigned = (var.managed_identities.system_assigned || length(var.managed_identities.user_assigned_resource_ids) > 0) ? {
       this = {

--- a/locals.tf
+++ b/locals.tf
@@ -4,7 +4,7 @@ locals {
     (contains(["rapid", "stable", "node-image"], var.automatic_upgrade_channel) && var.kubernetes_version == null && var.default_node_pool.orchestrator_version == null)
   )
   dns_prefix         = coalesce(var.dns_prefix, random_string.dns_prefix.result)
-  kube_admin_enabled = var.local_account_disabled == false ? try(lookup(var.azure_active_directory_role_based_access_control, "azure_rbac_enabled", false), false) : false
+  kube_admin_enabled = var.local_account_disabled ? false : try(lookup(var.azure_active_directory_role_based_access_control, "azure_rbac_enabled", false), false)
   managed_identities = {
     system_assigned_user_assigned = (var.managed_identities.system_assigned || length(var.managed_identities.user_assigned_resource_ids) > 0) ? {
       this = {

--- a/locals.tf
+++ b/locals.tf
@@ -3,15 +3,8 @@ locals {
     (contains(["patch"], var.automatic_upgrade_channel) && can(regex("^[0-9]{1,}\\.[0-9]{1,}$", var.kubernetes_version)) && (can(regex("^[0-9]{1,}\\.[0-9]{1,}$", var.default_node_pool.orchestrator_version)) || var.default_node_pool.orchestrator_version == null)) ||
     (contains(["rapid", "stable", "node-image"], var.automatic_upgrade_channel) && var.kubernetes_version == null && var.default_node_pool.orchestrator_version == null)
   )
-  dns_prefix = coalesce(var.dns_prefix, random_string.dns_prefix.result)
-  kube_admin_enabled = (
-    !var.local_account_disabled
-    ? (
-      var.azure_active_directory_role_based_access_control != null &&
-      try(lookup(var.azure_active_directory_role_based_access_control, "azure_rbac_enabled", false), false)
-    )
-    : false
-  )
+  dns_prefix         = coalesce(var.dns_prefix, random_string.dns_prefix.result)
+  kube_admin_enabled = var.local_account_disabled == false ? try(lookup(var.azure_active_directory_role_based_access_control, "azure_rbac_enabled", false), false) : false
   managed_identities = {
     system_assigned_user_assigned = (var.managed_identities.system_assigned || length(var.managed_identities.user_assigned_resource_ids) > 0) ? {
       this = {

--- a/main.tf
+++ b/main.tf
@@ -420,9 +420,9 @@ resource "azurerm_kubernetes_cluster" "this" {
 
     content {
       mode                             = service_mesh_profile.value.mode
-      revisions                        = service_mesh_profile.value.revisions
       external_ingress_gateway_enabled = service_mesh_profile.value.external_ingress_gateway_enabled
       internal_ingress_gateway_enabled = service_mesh_profile.value.internal_ingress_gateway_enabled
+      revisions                        = service_mesh_profile.value.revisions
 
       dynamic "certificate_authority" {
         for_each = service_mesh_profile.value.certificate_authority != null ? [service_mesh_profile.value.certificate_authority] : []
@@ -477,8 +477,8 @@ resource "azurerm_kubernetes_cluster" "this" {
     for_each = var.windows_profile != null ? [var.windows_profile] : []
 
     content {
-      admin_password = var.windows_profile_password
       admin_username = windows_profile.value.admin_username
+      admin_password = var.windows_profile_password
       license        = windows_profile.value.license
 
       dynamic "gmsa" {

--- a/main.tf
+++ b/main.tf
@@ -420,9 +420,9 @@ resource "azurerm_kubernetes_cluster" "this" {
 
     content {
       mode                             = service_mesh_profile.value.mode
+      revisions                        = service_mesh_profile.value.revisions
       external_ingress_gateway_enabled = service_mesh_profile.value.external_ingress_gateway_enabled
       internal_ingress_gateway_enabled = service_mesh_profile.value.internal_ingress_gateway_enabled
-      revisions                        = service_mesh_profile.value.revisions
 
       dynamic "certificate_authority" {
         for_each = service_mesh_profile.value.certificate_authority != null ? [service_mesh_profile.value.certificate_authority] : []
@@ -477,8 +477,8 @@ resource "azurerm_kubernetes_cluster" "this" {
     for_each = var.windows_profile != null ? [var.windows_profile] : []
 
     content {
-      admin_username = windows_profile.value.admin_username
       admin_password = var.windows_profile_password
+      admin_username = windows_profile.value.admin_username
       license        = windows_profile.value.license
 
       dynamic "gmsa" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,10 +6,7 @@ output "key_vault_secrets_provider_object_id" {
 output "kube_admin_config" {
   description = "The kube_admin_config block of the AKS cluster, only available when Local Accounts & Role-Based Access Control (RBAC) with AAD are enabled."
   sensitive   = true
-  value = (
-    lookup(var.azure_active_directory_role_based_access_control, "azure_rbac_enabled", false) == true &&
-    !var.local_account_disabled ? azurerm_kubernetes_cluster.this.kube_admin_config : null
-  )
+  value       = local.kube_admin_enabled ? azurerm_kubernetes_cluster.this.kube_admin_config : null
 }
 
 output "kubelet_identity_id" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,15 @@ output "key_vault_secrets_provider_object_id" {
   value       = try(azurerm_kubernetes_cluster.this.key_vault_secrets_provider[0].secret_identity[0].object_id, null)
 }
 
+output "kube_admin_config" {
+  description = "The kube_admin_config block of the AKS cluster, only available when Local Accounts & Role-Based Access Control (RBAC) with AAD are enabled."
+  sensitive   = true
+  value = (
+    lookup(var.azure_active_directory_role_based_access_control, "azure_rbac_enabled", false) == true &&
+    !var.local_account_disabled ? azurerm_kubernetes_cluster.this.kube_admin_config : null
+  )
+}
+
 output "kubelet_identity_id" {
   description = "The identity ID of the kubelet identity."
   value       = azurerm_kubernetes_cluster.this.kubelet_identity[0].object_id

--- a/variables.tf
+++ b/variables.tf
@@ -449,6 +449,7 @@ variable "local_account_disabled" {
   type        = bool
   default     = true
   description = "Defaults to true. Whether or not the local account should be disabled on the Kubernetes cluster. Azure RBAC must be enabled."
+  nullable    = false
 }
 
 variable "lock" {


### PR DESCRIPTION
## Description

Add new conditional output for kube_admin_config

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
