### PR TITLE
fix: maintenance window allowed hours

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,7 +598,7 @@ Type:
 object({
     allowed = object({
       day   = string
-      hours = number
+      hours = set(number)
     })
     not_allowed = object({
       start = string

--- a/variables.tf
+++ b/variables.tf
@@ -475,7 +475,7 @@ variable "maintenance_window" {
   type = object({
     allowed = object({
       day   = string
-      hours = number
+      hours = set(number)
     })
     not_allowed = object({
       start = string


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->
Maintenance Window allowed hours requires a set of numbers, not a single number.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
