### PR TITLE
feat: add host, cluster_ca_certificate and kube_config to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1189,6 +1189,14 @@ Default: `false`
 
 The following outputs are exported:
 
+### <a name="output_cluster_ca_certificate"></a> [cluster\_ca\_certificate](#output\_cluster\_ca\_certificate)
+
+Description: The CA certificate of the AKS cluster.
+
+### <a name="output_host"></a> [host](#output\_host)
+
+Description: The host of the AKS cluster API server.
+
 ### <a name="output_key_vault_secrets_provider_object_id"></a> [key\_vault\_secrets\_provider\_object\_id](#output\_key\_vault\_secrets\_provider\_object\_id)
 
 Description: The object ID of the key vault secrets provider.
@@ -1196,6 +1204,10 @@ Description: The object ID of the key vault secrets provider.
 ### <a name="output_kube_admin_config"></a> [kube\_admin\_config](#output\_kube\_admin\_config)
 
 Description: The kube\_admin\_config block of the AKS cluster, only available when Local Accounts & Role-Based Access Control (RBAC) with AAD are enabled.
+
+### <a name="output_kube_config"></a> [kube\_config](#output\_kube\_config)
+
+Description: The kube\_config block of the AKS cluster
 
 ### <a name="output_kubelet_identity_id"></a> [kubelet\_identity\_id](#output\_kubelet\_identity\_id)
 

--- a/main.telemetry.tf
+++ b/main.telemetry.tf
@@ -15,11 +15,11 @@ resource "random_uuid" "telemetry" {
 resource "modtm_telemetry" "telemetry" {
   count = var.enable_telemetry ? 1 : 0
 
-  tags = {
+  tags = merge({
     subscription_id = one(data.azurerm_client_config.telemetry).subscription_id
     tenant_id       = one(data.azurerm_client_config.telemetry).tenant_id
     module_source   = one(data.modtm_module_source.telemetry).module_source
     module_version  = one(data.modtm_module_source.telemetry).module_version
     random_id       = one(random_uuid.telemetry).result
-  }
+  }, { location = var.location })
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,15 @@
+output "cluster_ca_certificate" {
+  description = "The CA certificate of the AKS cluster."
+  sensitive   = true
+  value       = azurerm_kubernetes_cluster.this.kube_config
+}
+
+output "host" {
+  description = "The host of the AKS cluster API server."
+  sensitive   = true
+  value       = azurerm_kubernetes_cluster.this.kube_config[0].host
+}
+
 output "key_vault_secrets_provider_object_id" {
   description = "The object ID of the key vault secrets provider."
   value       = try(azurerm_kubernetes_cluster.this.key_vault_secrets_provider[0].secret_identity[0].object_id, null)
@@ -7,6 +19,12 @@ output "kube_admin_config" {
   description = "The kube_admin_config block of the AKS cluster, only available when Local Accounts & Role-Based Access Control (RBAC) with AAD are enabled."
   sensitive   = true
   value       = local.kube_admin_enabled ? azurerm_kubernetes_cluster.this.kube_admin_config : null
+}
+
+output "kube_config" {
+  description = "The kube_config block of the AKS cluster"
+  sensitive   = true
+  value       = azurerm_kubernetes_cluster.this.kube_config
 }
 
 output "kubelet_identity_id" {


### PR DESCRIPTION
## Description

Add host, cluster_ca_certificate and kube_config to outputs as described in #70.
Closes #70 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
