### PR TITLE
fix: maintenance window allowed hours and kubelet identity output (#62)

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,7 +598,7 @@ Type:
 object({
     allowed = object({
       day   = string
-      hours = number
+      hours = set(number)
     })
     not_allowed = object({
       start = string

--- a/main.telemetry.tf
+++ b/main.telemetry.tf
@@ -15,11 +15,11 @@ resource "random_uuid" "telemetry" {
 resource "modtm_telemetry" "telemetry" {
   count = var.enable_telemetry ? 1 : 0
 
-  tags = {
+  tags = merge({
     subscription_id = one(data.azurerm_client_config.telemetry).subscription_id
     tenant_id       = one(data.azurerm_client_config.telemetry).tenant_id
     module_source   = one(data.modtm_module_source.telemetry).module_source
     module_version  = one(data.modtm_module_source.telemetry).module_version
     random_id       = one(random_uuid.telemetry).result
-  }
+  }, { location = var.location })
 }

--- a/main.tf
+++ b/main.tf
@@ -557,13 +557,13 @@ resource "terraform_data" "kubernetes_version_keeper" {
 }
 
 resource "azapi_update_resource" "aks_cluster_post_create" {
-  type = "Microsoft.ContainerService/managedClusters@2024-02-01"
+  resource_id = azurerm_kubernetes_cluster.this.id
+  type        = "Microsoft.ContainerService/managedClusters@2024-02-01"
   body = {
     properties = {
       kubernetesVersion = var.kubernetes_version
     }
   }
-  resource_id = azurerm_kubernetes_cluster.this.id
 
   lifecycle {
     ignore_changes       = all
@@ -582,7 +582,8 @@ resource "terraform_data" "http_proxy_config_no_proxy_keeper" {
 resource "azapi_update_resource" "aks_cluster_http_proxy_config_no_proxy" {
   count = try(var.http_proxy_config.no_proxy != null, false) ? 1 : 0
 
-  type = "Microsoft.ContainerService/managedClusters@2024-02-01"
+  resource_id = azurerm_kubernetes_cluster.this.id
+  type        = "Microsoft.ContainerService/managedClusters@2024-02-01"
   body = {
     properties = {
       httpProxyConfig = {
@@ -590,7 +591,6 @@ resource "azapi_update_resource" "aks_cluster_http_proxy_config_no_proxy" {
       }
     }
   }
-  resource_id = azurerm_kubernetes_cluster.this.id
 
   depends_on = [azapi_update_resource.aks_cluster_post_create]
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -11,7 +11,7 @@ output "kube_admin_config" {
 
 output "kubelet_identity_id" {
   description = "The identity ID of the kubelet identity."
-  value       = azurerm_kubernetes_cluster.this.kubelet_identity[0].object_id
+  value       = try(azurerm_kubernetes_cluster.this.kubelet_identity[0].object_id, null)
 }
 
 output "name" {

--- a/variables.tf
+++ b/variables.tf
@@ -475,7 +475,7 @@ variable "maintenance_window" {
   type = object({
     allowed = object({
       day   = string
-      hours = number
+      hours = set(number)
     })
     not_allowed = object({
       start = string


### PR DESCRIPTION
* Update maintenance hours variable type
* Run pre-commit
* Closes #69 

## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
