### PR TITLE
fix: default node pool drain timeout

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -155,7 +155,7 @@ resource "azurerm_kubernetes_cluster" "this" {
 
         content {
           max_surge                     = upgrade_settings.value.max_surge
-          drain_timeout_in_minutes      = upgrade_settings.value.node_soak_duration_in_minutes
+          drain_timeout_in_minutes      = upgrade_settings.value.drain_timeout_in_minutes
           node_soak_duration_in_minutes = upgrade_settings.value.node_soak_duration_in_minutes
         }
       }
@@ -271,7 +271,7 @@ resource "azurerm_kubernetes_cluster" "this" {
       user_assigned_identity_id = kubelet_identity.value.user_assigned_identity_id
     }
   }
-  # OS Configuration 
+  # OS Configuration
   dynamic "linux_profile" {
     for_each = var.linux_profile != null ? [var.linux_profile] : []
 


### PR DESCRIPTION
## Description

Use correct value for setting `value.drain_timeout_in_minutes` for default node pool. Further description can be found in https://github.com/Azure/terraform-azurerm-avm-res-containerservice-managedcluster/issues/74

Closes #74 

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #74 
Closes #74 
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
