### PR TITLE
add gpu_driver variable that was added in azurerm v4.40.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.4)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.0.0, < 5.0.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.40.0, < 5.0.0)
 
 - <a name="requirement_modtm"></a> [modtm](#requirement\_modtm) (~> 0.3)
 
@@ -781,6 +781,7 @@ map(object({
     host_group_id                 = optional(string)
     fips_enabled                  = optional(bool)
     gpu_instance                  = optional(string)
+    gpu_driver                    = optional(string)
     kubelet_disk_type             = optional(string)
     max_pods                      = optional(number)
     mode                          = optional(string)

--- a/main.nodepool.tf
+++ b/main.nodepool.tf
@@ -11,6 +11,7 @@ module "nodepools" {
   create_nodepool_before_destroy = var.create_nodepools_before_destroy
   eviction_policy                = each.value.eviction_policy
   fips_enabled                   = each.value.fips_enabled
+  gpu_driver                     = each.value.gpu_driver
   gpu_instance                   = each.value.gpu_instance
   host_encryption_enabled        = each.value.host_encryption_enabled
   host_group_id                  = each.value.host_group_id

--- a/modules/nodepool/README.md
+++ b/modules/nodepool/README.md
@@ -11,7 +11,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.0.0, < 5.0.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.40.0, < 5.0.0)
 
 ## Resources
 
@@ -91,6 +91,14 @@ Default: `null`
 Description: Optional. Whether or not FIPS is enabled.
 
 Type: `bool`
+
+Default: `null`
+
+### <a name="input_gpu_driver"></a> [gpu\_driver](#input\_gpu\_driver)
+
+Description: Optional. Specifies whether to install the GPU Driver for the nodes. Possible values are Install and None. Changing this forces a new resource to be created.
+
+Type: `string`
 
 Default: `null`
 

--- a/modules/nodepool/main.tf
+++ b/modules/nodepool/main.tf
@@ -7,6 +7,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "this" {
   capacity_reservation_group_id = var.capacity_reservation_group_id
   eviction_policy               = var.eviction_policy
   fips_enabled                  = var.fips_enabled
+  gpu_driver                    = var.gpu_driver
   gpu_instance                  = var.gpu_instance
   host_encryption_enabled       = var.host_encryption_enabled
   host_group_id                 = var.host_group_id

--- a/modules/nodepool/terraform.tf
+++ b/modules/nodepool/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 4.0.0, < 5.0.0"
+      version = ">= 4.40.0, < 5.0.0"
     }
   }
 }

--- a/modules/nodepool/variables.tf
+++ b/modules/nodepool/variables.tf
@@ -58,6 +58,12 @@ variable "fips_enabled" {
   description = "Optional. Whether or not FIPS is enabled."
 }
 
+variable "gpu_driver" {
+  type        = string
+  default     = null
+  description = "Optional. Specifies whether to install the GPU Driver for the nodes. Possible values are Install and None. Changing this forces a new resource to be created."
+}
+
 variable "gpu_instance" {
   type        = string
   default     = null

--- a/terraform.tf
+++ b/terraform.tf
@@ -8,7 +8,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 4.0.0, < 5.0.0"
+      version = ">= 4.40.0, < 5.0.0"
     }
     modtm = {
       source  = "azure/modtm"

--- a/variables.tf
+++ b/variables.tf
@@ -638,6 +638,7 @@ variable "node_pools" {
     host_group_id                 = optional(string)
     fips_enabled                  = optional(bool)
     gpu_instance                  = optional(string)
+    gpu_driver                    = optional(string)
     kubelet_disk_type             = optional(string)
     max_pods                      = optional(number)
     mode                          = optional(string)


### PR DESCRIPTION
## Description

Added new variable gpu_driver introduced in azurerm v4.40.0 for azurerm_kubernetes_cluster_node_pool which cause recreation of node pools created with GPU. Azurerm version constraints lower bound have been increased to >= 4.40.0

Fixes #114 

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
