### PR TITLE
fix: remove redundant enableClusterAutoscaler assignments in locals

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -14,18 +14,17 @@ locals {
     } : {}
   )
   agent_pool_profile_template = {
-    availabilityZones       = null
-    count                   = null
-    enableAutoScaling       = null
-    enableClusterAutoscaler = null
-    maxCount                = null
-    minCount                = null
-    mode                    = null
-    name                    = null
-    osType                  = null
-    type                    = null
-    vmSize                  = null
-    vnetSubnetID            = null
+    availabilityZones = null
+    count             = null
+    enableAutoScaling = null
+    maxCount          = null
+    minCount          = null
+    mode              = null
+    name              = null
+    osType            = null
+    type              = null
+    vmSize            = null
+    vnetSubnetID      = null
   }
   agent_pool_profiles = local.agent_pool_profiles_raw == null ? null : [
     for profile in local.agent_pool_profiles_raw : {
@@ -52,18 +51,17 @@ locals {
     merge(
       local.agent_pool_profile_template,
       {
-        mode                    = "System"
-        osType                  = "Linux"
-        name                    = local.default_node_pool_name
-        count                   = local.default_node_pool_count
-        vmSize                  = var.default_node_pool.vm_size
-        enableAutoScaling       = var.default_node_pool.auto_scaling_enabled
-        enableClusterAutoscaler = var.default_node_pool.auto_scaling_enabled
-        minCount                = local.default_node_pool_min_count
-        maxCount                = local.default_node_pool_max_count
-        type                    = var.default_node_pool.type
-        vnetSubnetID            = var.default_node_pool.vnet_subnet_id
-        availabilityZones       = try(length(var.default_node_pool.zones) > 0 ? var.default_node_pool.zones : null, null)
+        mode              = "System"
+        osType            = "Linux"
+        name              = local.default_node_pool_name
+        count             = local.default_node_pool_count
+        vmSize            = var.default_node_pool.vm_size
+        enableAutoScaling = var.default_node_pool.auto_scaling_enabled
+        minCount          = local.default_node_pool_min_count
+        maxCount          = local.default_node_pool_max_count
+        type              = var.default_node_pool.type
+        vnetSubnetID      = var.default_node_pool.vnet_subnet_id
+        availabilityZones = try(length(var.default_node_pool.zones) > 0 ? var.default_node_pool.zones : null, null)
       }
     )
   ]

--- a/modules/nodepool/main.tf
+++ b/modules/nodepool/main.tf
@@ -23,7 +23,6 @@ locals {
   agent_pool_properties_base = {
     vmSize                     = var.vm_size
     enableAutoScaling          = var.auto_scaling_enabled
-    enableClusterAutoscaler    = var.auto_scaling_enabled
     capacityReservationGroupID = var.capacity_reservation_group_id
     scaleSetEvictionPolicy     = var.eviction_policy
     enableFIPS                 = var.fips_enabled


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

Remove `enableClusterAutoscaler` prop as it isn't supported any more in API version 2025-07-01.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
