### PR TITLE
fix: wrap trimspace() calls with try() for null safety

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -104,11 +104,11 @@ locals {
   default_node_pool_min_count = var.default_node_pool.min_count == null ? null : tonumber(var.default_node_pool.min_count)
   default_node_pool_name      = coalesce(try(var.default_node_pool.name, null), "systempool")
   is_automatic                = var.sku.name == "Automatic"
-  log_analytics_use_aad_auth  = var.log_analytics_workspace_id != null && trimspace(var.log_analytics_workspace_id) != "" ? true : try(var.oms_agent.msi_auth_for_monitoring_enabled, false)
+  log_analytics_use_aad_auth  = (var.log_analytics_workspace_id != null && try(trimspace(var.log_analytics_workspace_id), "") != "") ? true : try(var.oms_agent.msi_auth_for_monitoring_enabled, false)
   log_analytics_workspace_id = (
-    var.log_analytics_workspace_id != null && trimspace(var.log_analytics_workspace_id) != ""
+    var.log_analytics_workspace_id != null && try(trimspace(var.log_analytics_workspace_id), "") != ""
     ? var.log_analytics_workspace_id
-    : var.oms_agent != null && var.oms_agent.log_analytics_workspace_id != null && trimspace(var.oms_agent.log_analytics_workspace_id) != ""
+    : var.oms_agent != null && var.oms_agent.log_analytics_workspace_id != null && try(trimspace(var.oms_agent.log_analytics_workspace_id), "") != ""
     ? var.oms_agent.log_analytics_workspace_id
     : null
   )
@@ -147,7 +147,7 @@ locals {
       kubeStateMetrics = local.monitor_profile_kube_state_metrics
     } : {}
   )
-  monitor_workspace_id = var.monitor_workspace_id != null && trimspace(var.monitor_workspace_id) != "" ? var.monitor_workspace_id : null
+  monitor_workspace_id = var.monitor_workspace_id != null && try(trimspace(var.monitor_workspace_id), "") != "" ? var.monitor_workspace_id : null
   network_profile_advanced = var.advanced_networking.enabled ? {
     enabled       = true
     observability = var.advanced_networking.observability_enabled ? { enabled = true } : null

--- a/main.monitoring.tf
+++ b/main.monitoring.tf
@@ -15,7 +15,7 @@ module "monitoring" {
 # Alerting module - conditionally instantiated
 module "alerting" {
   source = "./modules/alerting"
-  count  = var.onboard_alerts && var.alert_email != null && trimspace(var.alert_email) != "" ? 1 : 0
+  count  = var.onboard_alerts && var.alert_email != null && try(trimspace(var.alert_email), "") != "" ? 1 : 0
 
   aks_cluster_id      = azapi_resource.this.id
   aks_cluster_name    = azapi_resource.this.name

--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,7 @@ resource "azapi_resource" "this" {
       error_message = "`onboard_monitoring` requires both `monitor_workspace_id` and `log_analytics_workspace_id` (or legacy `oms_agent.log_analytics_workspace_id`)."
     }
     precondition {
-      condition     = !var.onboard_alerts || (var.alert_email != null && trimspace(var.alert_email) != "")
+      condition     = !var.onboard_alerts || (var.alert_email != null && try(trimspace(var.alert_email), "") != "")
       error_message = "`onboard_alerts` requires a non-empty `alert_email`."
     }
     precondition {

--- a/variables.tf
+++ b/variables.tf
@@ -821,7 +821,7 @@ variable "onboard_alerts" {
   description = "Whether to enable recommended alerts. Set to false to disable alerts even if monitoring is enabled and alert_email is provided."
 
   validation {
-    condition     = !var.onboard_alerts || (var.alert_email != null && trimspace(var.alert_email) != "")
+    condition     = !var.onboard_alerts || (var.alert_email != null && try(trimspace(var.alert_email), "") != "")
     error_message = "When `onboard_alerts` is true, `alert_email` must be provided."
   }
 }
@@ -833,9 +833,9 @@ variable "onboard_monitoring" {
 
   validation {
     condition = !var.onboard_monitoring || (
-      var.monitor_workspace_id != null && trimspace(var.monitor_workspace_id) != "" && (
-        (var.log_analytics_workspace_id != null && trimspace(var.log_analytics_workspace_id) != "") ||
-        (var.oms_agent != null && var.oms_agent.log_analytics_workspace_id != null && trimspace(var.oms_agent.log_analytics_workspace_id) != "")
+      var.monitor_workspace_id != null && try(trimspace(var.monitor_workspace_id), "") != "" && (
+        (var.log_analytics_workspace_id != null && try(trimspace(var.log_analytics_workspace_id), "") != "") ||
+        (var.oms_agent != null && var.oms_agent.log_analytics_workspace_id != null && try(trimspace(var.oms_agent.log_analytics_workspace_id), "") != "")
       )
     )
     error_message = "When `onboard_monitoring` is true, provide `monitor_workspace_id` and either `log_analytics_workspace_id` or `oms_agent.log_analytics_workspace_id`."


### PR DESCRIPTION
- Added try() wrapper around all trimspace() calls to prevent errors when null values are encountered
- Removed duplicate log_analytics_use_aad_auth definition in locals.tf
- Applied consistent null-safe pattern across locals.tf, main.tf, main.monitoring.tf, and variables.tf

## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
