### PR TITLE
Generate DNS prefix when unset

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The following resources are used by this module:
 - [azurerm_private_endpoint_application_security_group_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint_application_security_group_association) (resource)
 - [azurerm_role_assignment.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) (resource)
 - [modtm_telemetry.telemetry](https://registry.terraform.io/providers/azure/modtm/latest/docs/resources/telemetry) (resource)
+- [random_string.dns_prefix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) (resource)
 - [random_uuid.telemetry](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) (resource)
 - [azapi_client_config.telemetry](https://registry.terraform.io/providers/Azure/azapi/latest/docs/data-sources/client_config) (data source)
 - [modtm_module_source.telemetry](https://registry.terraform.io/providers/azure/modtm/latest/docs/data-sources/module_source) (data source)
@@ -1038,7 +1039,8 @@ Default: `null`
 
 ### <a name="input_dns_prefix"></a> [dns\_prefix](#input\_dns\_prefix)
 
-Description: The DNS prefix of the Managed Cluster. This cannot be updated once the Managed Cluster has been created.
+Description: The DNS prefix of the Managed Cluster. This cannot be updated once the Managed Cluster has been created.  
+If not specified, a random DNS prefix will be generated.
 
 Type: `string`
 

--- a/locals.resource_body.tf
+++ b/locals.resource_body.tf
@@ -80,7 +80,7 @@ locals {
       }
       disableLocalAccounts = var.disable_local_accounts
       diskEncryptionSetID  = var.disk_encryption_set_id
-      dnsPrefix            = var.dns_prefix
+      dnsPrefix            = coalesce(var.dns_prefix, random_string.dns_prefix.result)
       enableRBAC           = var.enable_rbac
       fqdnSubdomain        = var.fqdn_subdomain
       httpProxyConfig = var.http_proxy_config == null ? null : {

--- a/main.tf
+++ b/main.tf
@@ -60,6 +60,14 @@ resource "azapi_resource" "this" {
   }
 }
 
+resource "random_string" "dns_prefix" {
+  length  = 10
+  lower   = true
+  numeric = true
+  special = false
+  upper   = false
+}
+
 moved {
   from = azurerm_kubernetes_cluster.this
   to   = azapi_resource.this

--- a/variables.tf
+++ b/variables.tf
@@ -584,6 +584,7 @@ variable "dns_prefix" {
   default     = null
   description = <<DESCRIPTION
 The DNS prefix of the Managed Cluster. This cannot be updated once the Managed Cluster has been created.
+If not specified, a random DNS prefix will be generated.
 DESCRIPTION
 }
 


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #149
Closes #149
-->

This PR contains the fix for issue #149. It generates a random DNS prefix when `var.dns_prefix` is not set.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
