### PR TITLE
Allow latest opentofu version

### DIFF
--- a/modules/agentpool/version_override.tofu
+++ b/modules/agentpool/version_override.tofu
@@ -1,0 +1,3 @@
+terraform {
+  required_version = "~>1.11"
+}

--- a/modules/maintenanceconfiguration/version_override.tofu
+++ b/modules/maintenanceconfiguration/version_override.tofu
@@ -1,0 +1,3 @@
+terraform {
+  required_version = "~>1.11"
+}

--- a/modules/namespace/version_override.tofu
+++ b/modules/namespace/version_override.tofu
@@ -1,0 +1,3 @@
+terraform {
+  required_version = "~>1.11"
+}

--- a/version_override.tofu
+++ b/version_override.tofu
@@ -1,0 +1,3 @@
+terraform {
+  required_version = "~>1.11"
+}


### PR DESCRIPTION

## Description

Hello,

it is not possible to use this avm with the latest OpenTofu version at the moment.
I'm aware of this statement: https://github.com/Azure/Azure-Verified-Modules/discussions/1512

That said, it also states that:
"To maintain broad compatibility, we advise keeping Terraform version constraints at a minimum required level for the Terraform features that you require in the module."
I don't see new terraform features being used, so the minimum required version could be lowered or a *_override.tofu file can be added to support the latest opentofu version.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
