### PR TITLE
feat: add azapi locks to agent pool resources to prevent concurrent modifications

### DIFF
--- a/main.default_agent_pool.tf
+++ b/main.default_agent_pool.tf
@@ -63,6 +63,9 @@ resource "azapi_update_resource" "default_agent_pool" {
   body = {
     properties = { for k, v in module.default_agent_pool_data.body_properties : k => v if v != null }
   }
+  locks = [
+    azapi_resource.this.id,
+  ]
   read_headers   = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   update_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 }

--- a/modules/agentpool/main.tf
+++ b/modules/agentpool/main.tf
@@ -11,11 +11,14 @@ moved {
 resource "azapi_resource" "this" {
   count = var.output_data_only ? 0 : var.create_before_destroy ? 0 : 1
 
-  name                  = var.name
-  parent_id             = var.parent_id
-  type                  = "Microsoft.ContainerService/managedClusters/agentPools@2025-10-01"
-  body                  = local.resource_body
-  ignore_null_property  = true
+  name                 = var.name
+  parent_id            = var.parent_id
+  type                 = "Microsoft.ContainerService/managedClusters/agentPools@2025-10-01"
+  body                 = local.resource_body
+  ignore_null_property = true
+  locks = [
+    var.parent_id
+  ]
   replace_triggers_refs = local.replace_triggers_refs
   response_export_values = [
     "properties.currentOrchestratorVersion",
@@ -40,11 +43,14 @@ resource "azapi_resource" "this" {
 resource "azapi_resource" "this_create_before_destroy" {
   count = var.output_data_only ? 0 : var.create_before_destroy ? 1 : 0
 
-  name                  = "${var.name}${substr(sha256(uuid()), 0, 4)}"
-  parent_id             = var.parent_id
-  type                  = "Microsoft.ContainerService/managedClusters/agentPools@2025-10-01"
-  body                  = local.resource_body
-  ignore_null_property  = true
+  name                 = "${var.name}${substr(sha256(uuid()), 0, 4)}"
+  parent_id            = var.parent_id
+  type                 = "Microsoft.ContainerService/managedClusters/agentPools@2025-10-01"
+  body                 = local.resource_body
+  ignore_null_property = true
+  locks = [
+    var.parent_id
+  ]
   replace_triggers_refs = local.replace_triggers_refs
   response_export_values = [
     "properties.currentOrchestratorVersion",


### PR DESCRIPTION
## Summary

- Adds `locks` to all `azapi_resource` and `azapi_update_resource` blocks for agent pools, locking on the parent AKS cluster resource ID (`parent_id` or `azapi_resource.this.id`)
- This prevents concurrent modifications to agent pools under the same AKS cluster, avoiding race conditions and API conflicts during parallel Terraform operations

## Motivation

When multiple agent pools are managed under a single AKS cluster, Terraform may attempt to create, update, or delete them concurrently. The AKS API does not support concurrent modifications to agent pools on the same cluster, which can lead to:

- `409 Conflict` errors from the Azure API
- Failed or partially applied Terraform plans
- Inconsistent cluster state requiring manual intervention

The `locks` argument in `azapi` ensures that operations on agent pools targeting the same parent cluster are serialized, eliminating these race conditions.

## Changes

| File | Change |
|------|--------|
| `main.default_agent_pool.tf` | Added `locks = [azapi_resource.this.id]` to `azapi_update_resource.default_agent_pool` |
| `modules/agentpool/main.tf` | Added `locks = [var.parent_id]` to both `azapi_resource.this` and `azapi_resource.this_create_before_destroy` |

## Testing

- [x] `./avm pre-commit` passed
- [x] `./avm pr-check` passed (linting, docs, tflint, grept, mapotf, avmfix, well-architected)