### PR TITLE
chore: drop Terraform version requirement from ~> 1.12 to ~> 1.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.12)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.11)
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.4)
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -14,7 +14,7 @@ This major release migrates the underlying provider from `azurerm_kubernetes_clu
 
 | Version   | Old (AzureRM)   | New (AzAPI) |
 | --------- | --------------- | ----------- |
-| Terraform | `>= 1.9, < 2.0` | `~> 1.12`   |
+| Terraform | `>= 1.9, < 2.0` | `~> 1.11`   |
 
 ## Provider Requirements
 
@@ -971,7 +971,7 @@ moved {
 
 ## Migration Checklist
 
-1. [ ] Update Terraform version to `~> 1.12`
+1. [ ] Update Terraform version to `~> 1.11`
 2. [ ] Add AzAPI provider to your provider configuration
 3. [ ] Replace `resource_group_name` with `parent_id` (full resource ID)
 4. [ ] Replace `sku_tier` with `sku` object

--- a/examples/namespaces/README.md
+++ b/examples/namespaces/README.md
@@ -6,7 +6,7 @@ This deploys the module with AKS Automatic Mode and managed namespaces, demonstr
 
 ```hcl
 terraform {
-  required_version = "~> 1.12"
+  required_version = "~> 1.11"
 
   required_providers {
     azurerm = {
@@ -169,7 +169,7 @@ module "namespaces" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.12)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.11)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.46.0, < 5.0.0)
 

--- a/examples/namespaces/main.tf
+++ b/examples/namespaces/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.12"
+  required_version = "~> 1.11"
 
   required_providers {
     azurerm = {

--- a/modules/agentpool/README.md
+++ b/modules/agentpool/README.md
@@ -7,7 +7,7 @@
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.12)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.11)
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.7)
 

--- a/modules/agentpool/terraform.tf
+++ b/modules/agentpool/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.12"
+  required_version = "~> 1.11"
 
   required_providers {
     azapi = {

--- a/modules/maintenanceconfiguration/README.md
+++ b/modules/maintenanceconfiguration/README.md
@@ -7,7 +7,7 @@
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.12)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.11)
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.7)
 

--- a/modules/maintenanceconfiguration/terraform.tf
+++ b/modules/maintenanceconfiguration/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.12"
+  required_version = "~> 1.11"
 
   required_providers {
     azapi = {

--- a/modules/namespace/README.md
+++ b/modules/namespace/README.md
@@ -7,7 +7,7 @@
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.12)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.11)
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.7)
 

--- a/modules/namespace/terraform.tf
+++ b/modules/namespace/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.12"
+  required_version = "~> 1.11"
 
   required_providers {
     azapi = {

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.12"
+  required_version = "~> 1.11"
 
   required_providers {
     azapi = {


### PR DESCRIPTION
## Summary

- Lowers the `required_version` constraint from `~> 1.12` to `~> 1.11` across the root module, submodules, and examples
- Updates `UPGRADE.md` documentation to reflect the new minimum version

## Rationale

A full scan of the codebase found **no Terraform 1.12-specific features** in use. The only "modern" language feature used is `ephemeral = true` on the `windows_profile_password` variable (`variables.tf:1391`), which was introduced in **Terraform 1.10.0**, not 1.12.

Terraform 1.12.0 features (none used in this codebase):
- OCI Object Storage backend
- `identity` attribute on `import` blocks
- Test parallelism (`-parallelism=n`)
- Logical binary operator short-circuiting
- Parallel test execution annotations

## Files Changed

| File | Change |
|---|---|
| `terraform.tf` | `~> 1.12` → `~> 1.11` |
| `modules/agentpool/terraform.tf` | `~> 1.12` → `~> 1.11` |
| `modules/maintenanceconfiguration/terraform.tf` | `~> 1.12` → `~> 1.11` |
| `modules/namespace/terraform.tf` | `~> 1.12` → `~> 1.11` |
| `examples/namespaces/main.tf` | `~> 1.12` → `~> 1.11` |
| `UPGRADE.md` | Updated version references |
| `README.md` (auto-generated) | Updated by pre-commit |
| `modules/*/README.md` (auto-generated) | Updated by pre-commit |
| `examples/namespaces/README.md` (auto-generated) | Updated by pre-commit |