### PR TITLE
fix: ignore read only outputs from update resource

### DIFF
--- a/main.default_agent_pool.tf
+++ b/main.default_agent_pool.tf
@@ -66,6 +66,7 @@ resource "azapi_update_resource" "default_agent_pool" {
   locks = [
     azapi_resource.this.id,
   ]
-  read_headers   = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  update_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  response_export_values = []
+  update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 }


### PR DESCRIPTION
## Summary

- Adds `response_export_values = []` to the `azapi_update_resource.default_agent_pool` resource to explicitly ignore read-only outputs from the update resource, preventing unnecessary diffs and plan noise.