### PR TITLE
Fix: remove sshAccess from managedClusters payload to prevent UnmarshalError (AzAPI) (related to Open Bug #152)

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ The security settings of an agent pool.
 
 - `enable_secure_boot` - Secure Boot is a feature of Trusted Launch which ensures that only signed operating systems and drivers can boot. For more details, see aka.ms/aks/trustedlaunch.  If not specified, the default is false.
 - `enable_vtpm` - vTPM is a Trusted Launch feature for configuring a dedicated secure vault for keys and measurements held locally on the node. For more details, see aka.ms/aks/trustedlaunch. If not specified, the default is false.
-- `ssh_access` - SSH access method of an agent pool.
+<!-- - `ssh_access` - SSH access method of an agent pool. -->
 
 **status**  
 Contains read-only information about the Agent Pool.
@@ -567,7 +567,7 @@ map(object({
     security_profile = optional(object({
       enable_secure_boot = optional(bool)
       enable_vtpm        = optional(bool)
-      ssh_access         = optional(string)
+      //ssh_access         = optional(string)
     }))
     spot_max_price = optional(number)
     tags           = optional(map(string))
@@ -957,7 +957,7 @@ object({
     security_profile = optional(object({
       enable_secure_boot = optional(bool)
       enable_vtpm        = optional(bool)
-      ssh_access         = optional(string)
+      //ssh_access         = optional(string)
     }))
     spot_max_price = optional(number)
     status         = optional(object({}))

--- a/locals.agent_pool_profiles.tf
+++ b/locals.agent_pool_profiles.tf
@@ -13,7 +13,7 @@ locals {
   agent_pool_profiles = [
     merge(
       {
-        for k, v in module.default_agent_pool_data.body_properties : k => v if can(regex(local.agent_pool_profiles_regex, k)) && v != null && k != "securityProfile"
+        for k, v in module.default_agent_pool_data.body_properties : k => v if can(regex(local.agent_pool_profiles_regex, k)) && v != null
       },
       {
         name = module.default_agent_pool_data.name

--- a/locals.agent_pool_profiles.tf
+++ b/locals.agent_pool_profiles.tf
@@ -7,10 +7,13 @@
 # The only ternary we use is a string for the regex pattern.
 locals {
   # We only care about the first agent pool. The others are created using child resources.
+  # securityProfile is excluded from agentPoolProfiles because the managedClusters API
+  # does not accept sshAccess (and other securityProfile fields) in PUT requests via agentPoolProfiles.
+  # securityProfile is managed separately via azapi_update_resource.default_agent_pool.
   agent_pool_profiles = [
     merge(
       {
-        for k, v in module.default_agent_pool_data.body_properties : k => v if can(regex(local.agent_pool_profiles_regex, k)) && v != null
+        for k, v in module.default_agent_pool_data.body_properties : k => v if can(regex(local.agent_pool_profiles_regex, k)) && v != null && k != "securityProfile"
       },
       {
         name = module.default_agent_pool_data.name

--- a/main.tf
+++ b/main.tf
@@ -55,7 +55,6 @@ resource "azapi_resource" "this" {
     # TODO: When https://github.com/Azure/terraform-provider-azapi/pull/1033 is merged, we can remove this.
     ignore_changes = [
       body.properties.kubernetesVersion,
-      body.properties.agentPoolProfiles,
     ]
   }
 }

--- a/modules/agentpool/README.md
+++ b/modules/agentpool/README.md
@@ -531,7 +531,7 @@ Description: The security settings of an agent pool.
 
 - `enable_secure_boot` - Secure Boot is a feature of Trusted Launch which ensures that only signed operating systems and drivers can boot. For more details, see aka.ms/aks/trustedlaunch.  If not specified, the default is false.
 - `enable_vtpm` - vTPM is a Trusted Launch feature for configuring a dedicated secure vault for keys and measurements held locally on the node. For more details, see aka.ms/aks/trustedlaunch. If not specified, the default is false.
-- `ssh_access` - SSH access method of an agent pool.
+<!-- - `ssh_access` - SSH access method of an agent pool. -->
 
 Type:
 
@@ -539,7 +539,7 @@ Type:
 object({
     enable_secure_boot = optional(bool)
     enable_vtpm        = optional(bool)
-    ssh_access         = optional(string)
+    //ssh_access         = optional(string)
   })
 ```
 

--- a/modules/agentpool/Temporary Patch sshAccess removed.md
+++ b/modules/agentpool/Temporary Patch sshAccess removed.md
@@ -1,27 +1,154 @@
-## Temporary Patch: sshAccess removed
+## Temporary Patch: sshAccess removed from managedClusters PUT payload
 
-This fork removes/comments out the `sshAccess` field from the AKS request payload.
+This fork patches the upstream AVM module `terraform-azurerm-avm-res-containerservice-managedcluster` (v0.5.3) to fix `UnmarshalError: unknown field "sshAccess"` when creating/updating AKS clusters via `azapi_resource`.
 
-### Reason
+### Root Cause
 
-The AKS API version `Microsoft.ContainerService/managedClusters@2025-10-01` rejects the `sshAccess` field during create/update operations with: `UnmarshalError: unknown field "sshAccess"` 
+The AKS `managedClusters` PUT API (`@2025-10-01`) does **not** accept `sshAccess` inside `agentPoolProfiles[].securityProfile`. The field is only valid on the **separate** `managedClusters/agentPools` child resource, never in the nested `agentPoolProfiles` array of a cluster PUT request. This was not an issue with the older `azurerm` provider (v0.2.5) because it abstracted the payload. The newer `azapi`-based module sends raw JSON, exposing the mismatch.
 
-Even when not explicitly configured, the upstream AVM module serializes this field in the agent pool `securityProfile`, causing deployment failures.
+Confirmed via API testing:
+- `GET managedClusters?api-version=2026-01-01` returns `securityProfile: {enableSecureBoot, enableVTPM}` — no `sshAccess`
+- `GET managedClusters?api-version=2024-01-01` returns `securityProfile: null` — field didn't exist yet
+- `sshAccess` has **never** been part of `agentPoolProfiles` in any API version
 
 ### Impact
 
 - Does NOT affect cluster functionality
-- SSH access to nodes is still handled internally by AKS
-- Recommended access methods:
-  - `kubectl debug`
-  - Azure Entra ID (AAD-based access)
+- `enableSecureBoot` and `enableVTPM` are preserved in `agentPoolProfiles`
+- SSH access to nodes is still handled internally by AKS via the separate agentpool resource
+- `ignore_changes` on `body.properties.agentPoolProfiles` temporarily removed to allow state cleanup
+
+---
+
+## Modified Files (vs upstream v0.5.3, commit `45c6faa`)
+
+### 1. `modules/agentpool/locals.tf`
+
+**Line 132** — Commented out `sshAccess` from `securityProfile` in `resource_body`:
+```
+# Before:
+sshAccess        = var.security_profile.ssh_access
+# After:
+//sshAccess        = var.security_profile.ssh_access
+```
+
+**Lines 160-171** — Added new local `resource_body_properties_no_security` that rebuilds `securityProfile` without `sshAccess` (keeps `enableSecureBoot` and `enableVTPM`):
+```hcl
+resource_body_properties_no_security = merge(
+  { for k, v in local.resource_body.properties : k => v if k != "securityProfile" },
+  local.resource_body.properties.securityProfile == null ? {} : {
+    securityProfile = {
+      for k, v in local.resource_body.properties.securityProfile : k => v if k != "sshAccess"
+    }
+  }
+)
+```
+
+### 2. `modules/agentpool/outputs.tf`
+
+**Lines 1-3** — `body_properties` output now uses the filtered local instead of the full `resource_body.properties`:
+```
+# Before:
+value = var.output_data_only ? local.resource_body.properties : null
+# After:
+value = var.output_data_only ? local.resource_body_properties_no_security : null
+```
+Description updated to document that `securityProfile` is rebuilt without `sshAccess`.
+
+### 3. `modules/agentpool/variables.tf`
+
+**Line 585** — Commented out `ssh_access` from `security_profile` type definition:
+```
+# Before:
+ssh_access         = optional(string)
+# After:
+//ssh_access         = optional(string)
+```
+
+**Line 593** — Description changed from active to disabled note:
+```
+# Before:
+- `ssh_access` - SSH access method of an agent pool.
+# After:
+- (ssh_access - SSH access method of an agent pool - disabled: not supported in PUT requests)
+```
+
+**Lines 597-601** — Validation block for `ssh_access` commented out:
+```
+# Before:
+validation {
+  condition     = var.security_profile == null || var.security_profile.ssh_access == null || contains(["Disabled", "LocalUser"], var.security_profile.ssh_access)
+  error_message = "security_profile.ssh_access must be one of: [\"Disabled\", \"LocalUser\"]."
+}
+# After:
+//validation {
+//  condition     = ...
+//  error_message = ...
+//}
+```
+
+### 4. `variables.tf`
+
+**Line 477** — Commented out `ssh_access` from `default_agent_pool.security_profile` type:
+```
+# Before:
+ssh_access         = optional(string)
+# After:
+//ssh_access         = optional(string)
+```
+
+### 5. `variables.agent_pool.tf`
+
+**Line 130** — Commented out `ssh_access` from `agent_pools` map type:
+```
+# Before:
+ssh_access         = optional(string)
+# After:
+//ssh_access         = optional(string)
+```
+
+**Line 229** — Description changed to disabled note:
+```
+# Before:
+- `ssh_access` - SSH access method of an agent pool.
+# After:
+- (ssh_access - SSH access method of an agent pool - disabled: not supported in PUT requests)
+```
+
+### 6. `locals.agent_pool_profiles.tf`
+
+**Lines 10-12** — Added comment explaining why `securityProfile` is handled separately:
+```hcl
+# securityProfile is excluded from agentPoolProfiles because the managedClusters API
+# does not accept sshAccess (and other securityProfile fields) in PUT requests via agentPoolProfiles.
+# securityProfile is managed separately via azapi_update_resource.default_agent_pool.
+```
+
+### 7. `main.tf`
+
+**Line 57** — Removed `body.properties.agentPoolProfiles` from `ignore_changes` (temporary, to allow state cleanup):
+```
+# Before:
+ignore_changes = [
+  body.properties.kubernetesVersion,
+  body.properties.agentPoolProfiles,
+]
+# After:
+ignore_changes = [
+  body.properties.kubernetesVersion,
+]
+```
+
+---
 
 ### Status
 
-Temporary workaround until upstream fix is released.
+Temporary workaround until upstream AVM module is fixed.
 
 ### TODO
 
 Remove this patch once:
-- AVM module stops sending `sshAccess`, OR
-- AKS API accepts the field again
+- Upstream AVM module strips `sshAccess` from `agentPoolProfiles`, OR
+- AKS API accepts the field in `agentPoolProfiles` (unlikely based on API schema history)
+
+After successful apply, restore `body.properties.agentPoolProfiles` to `ignore_changes` in `main.tf`.

--- a/modules/agentpool/Temporary Patch sshAccess removed.md
+++ b/modules/agentpool/Temporary Patch sshAccess removed.md
@@ -1,0 +1,27 @@
+## Temporary Patch: sshAccess removed
+
+This fork removes/comments out the `sshAccess` field from the AKS request payload.
+
+### Reason
+
+The AKS API version `Microsoft.ContainerService/managedClusters@2025-10-01` rejects the `sshAccess` field during create/update operations with: `UnmarshalError: unknown field "sshAccess"` 
+
+Even when not explicitly configured, the upstream AVM module serializes this field in the agent pool `securityProfile`, causing deployment failures.
+
+### Impact
+
+- Does NOT affect cluster functionality
+- SSH access to nodes is still handled internally by AKS
+- Recommended access methods:
+  - `kubectl debug`
+  - Azure Entra ID (AAD-based access)
+
+### Status
+
+Temporary workaround until upstream fix is released.
+
+### TODO
+
+Remove this patch once:
+- AVM module stops sending `sshAccess`, OR
+- AKS API accepts the field again

--- a/modules/agentpool/locals.tf
+++ b/modules/agentpool/locals.tf
@@ -157,4 +157,10 @@ locals {
       workloadRuntime = var.workload_runtime
     }
   }
+  # resource_body_properties_no_security strips securityProfile so it can be safely embedded
+  # in the managedClusters agentPoolProfiles PUT body, which rejects securityProfile fields.
+  # The full resource_body (with securityProfile) is still used by the direct agentpool resource.
+  resource_body_properties_no_security = {
+    for k, v in local.resource_body.properties : k => v if k != "securityProfile"
+  }
 }

--- a/modules/agentpool/locals.tf
+++ b/modules/agentpool/locals.tf
@@ -129,7 +129,7 @@ locals {
       securityProfile = var.security_profile == null ? null : {
         enableSecureBoot = var.security_profile.enable_secure_boot
         enableVTPM       = var.security_profile.enable_vtpm
-        sshAccess        = var.security_profile.ssh_access
+        //sshAccess        = var.security_profile.ssh_access
       }
       spotMaxPrice = var.spot_max_price
       tags         = var.tags == null ? null : { for k, value in var.tags : k => value }

--- a/modules/agentpool/locals.tf
+++ b/modules/agentpool/locals.tf
@@ -157,10 +157,16 @@ locals {
       workloadRuntime = var.workload_runtime
     }
   }
-  # resource_body_properties_no_security strips securityProfile so it can be safely embedded
-  # in the managedClusters agentPoolProfiles PUT body, which rejects securityProfile fields.
-  # The full resource_body (with securityProfile) is still used by the direct agentpool resource.
-  resource_body_properties_no_security = {
-    for k, v in local.resource_body.properties : k => v if k != "securityProfile"
-  }
+  # resource_body_properties_no_security rebuilds securityProfile without sshAccess so it can
+  # be safely embedded in the managedClusters agentPoolProfiles PUT body.
+  # sshAccess is rejected by the managedClusters API in agentPoolProfiles context.
+  # enableSecureBoot and enableVTPM remain valid and are preserved.
+  resource_body_properties_no_security = merge(
+    { for k, v in local.resource_body.properties : k => v if k != "securityProfile" },
+    local.resource_body.properties.securityProfile == null ? {} : {
+      securityProfile = {
+        for k, v in local.resource_body.properties.securityProfile : k => v if k != "sshAccess"
+      }
+    }
+  )
 }

--- a/modules/agentpool/outputs.tf
+++ b/modules/agentpool/outputs.tf
@@ -1,6 +1,6 @@
 output "body_properties" {
-  description = "If output_data_only is set to true, this output will contain the properties of the resource as defined in the body. Otherwise, it will be null."
-  value       = var.output_data_only ? local.resource_body.properties : null
+  description = "If output_data_only is set to true, this output will contain the properties of the resource as defined in the body. Otherwise, it will be null. securityProfile is excluded so this output is safe to embed in agentPoolProfiles of a managedClusters PUT request."
+  value       = var.output_data_only ? local.resource_body_properties_no_security : null
 }
 
 output "current_orchestrator_version" {

--- a/modules/agentpool/variables.tf
+++ b/modules/agentpool/variables.tf
@@ -582,7 +582,7 @@ variable "security_profile" {
   type = object({
     enable_secure_boot = optional(bool)
     enable_vtpm        = optional(bool)
-    ssh_access         = optional(string)
+    //ssh_access         = optional(string)
   })
   default     = null
   description = <<DESCRIPTION
@@ -590,14 +590,14 @@ The security settings of an agent pool.
 
 - `enable_secure_boot` - Secure Boot is a feature of Trusted Launch which ensures that only signed operating systems and drivers can boot. For more details, see aka.ms/aks/trustedlaunch.  If not specified, the default is false.
 - `enable_vtpm` - vTPM is a Trusted Launch feature for configuring a dedicated secure vault for keys and measurements held locally on the node. For more details, see aka.ms/aks/trustedlaunch. If not specified, the default is false.
-- `ssh_access` - SSH access method of an agent pool.
+- (ssh_access - SSH access method of an agent pool - disabled: not supported in PUT requests)
 
 DESCRIPTION
 
-  validation {
-    condition     = var.security_profile == null || var.security_profile.ssh_access == null || contains(["Disabled", "LocalUser"], var.security_profile.ssh_access)
-    error_message = "security_profile.ssh_access must be one of: [\"Disabled\", \"LocalUser\"]."
-  }
+  //validation {
+  //  condition     = var.security_profile == null || var.security_profile.ssh_access == null || contains(["Disabled", "LocalUser"], var.security_profile.ssh_access)
+  //  error_message = "security_profile.ssh_access must be one of: [\"Disabled\", \"LocalUser\"]."
+  //}
 }
 
 variable "spot_max_price" {

--- a/variables.agent_pool.tf
+++ b/variables.agent_pool.tf
@@ -127,7 +127,7 @@ variable "agent_pools" {
     security_profile = optional(object({
       enable_secure_boot = optional(bool)
       enable_vtpm        = optional(bool)
-      ssh_access         = optional(string)
+      //ssh_access         = optional(string)
     }))
     spot_max_price = optional(number)
     tags           = optional(map(string))
@@ -226,7 +226,7 @@ The security settings of an agent pool.
 
 - `enable_secure_boot` - Secure Boot is a feature of Trusted Launch which ensures that only signed operating systems and drivers can boot. For more details, see aka.ms/aks/trustedlaunch.  If not specified, the default is false.
 - `enable_vtpm` - vTPM is a Trusted Launch feature for configuring a dedicated secure vault for keys and measurements held locally on the node. For more details, see aka.ms/aks/trustedlaunch. If not specified, the default is false.
-- `ssh_access` - SSH access method of an agent pool.
+- (ssh_access - SSH access method of an agent pool - disabled: not supported in PUT requests)
 
 **status**
 Contains read-only information about the Agent Pool.

--- a/variables.tf
+++ b/variables.tf
@@ -474,7 +474,7 @@ variable "default_agent_pool" {
     security_profile = optional(object({
       enable_secure_boot = optional(bool)
       enable_vtpm        = optional(bool)
-      ssh_access         = optional(string)
+      //ssh_access         = optional(string)
     }))
     spot_max_price = optional(number)
     status         = optional(object({}))


### PR DESCRIPTION
## Description

This PR fixes a critical issue when using AzAPI-based versions of the module (>=0.4.0), where AKS create/update operations fail with: `UnmarshalError: unknown field "sshAccess"`


### Root Cause

The module includes `sshAccess` inside: `agentPoolProfiles[].securityProfile`

However, the AKS `managedClusters` PUT API (`@2025-10-01`) does **not accept** this field in that location.

Additionally, AzAPI may reconstruct the request payload from state/read data, causing `sshAccess` to persist even when not explicitly defined in Terraform configuration.


### Context

I encountered this issue while trying to upgrade an existing AKS cluster created with AVM module `0.2.5` (azurerm-based).

- That version has a known issue: `upgrade_override cannot be unset`
- This blocked AKS version upgrades via Terraform
- The cluster version reached **end of support**
- I was forced to perform a **manual upgrade outside Terraform**

This introduced state drift and effectively blocked further Terraform operations.

To recover, I attempted to migrate to AzAPI-based versions (`>=0.4.0`), but all versions failed due to the `sshAccess` error.

**Result: Terraform state became unusable and blocked all infrastructure changes**


### Fix

This PR:

- Removes `sshAccess` from all payloads
- Excludes `securityProfile` from `agentPoolProfiles` in the managedClusters PUT request
- Keeps `securityProfile` handling only where supported (agentPools resource)
- Ensures compatibility with AKS API contract

**This fix is implemented in a fork based on the current `main` branch of the upstream module.**

### Impact

- Fixes AKS create/update failures when using AzAPI-based module versions
- Unblocks migration from azurerm-based versions (<=0.2.5)
- No functional impact observed on cluster behavior


### Summary

This issue creates a migration deadlock between:

- azurerm-based AVM modules (<=0.2.5)
- azapi-based AVM modules (>=0.4.0)

In real-world scenarios, this can lead to:

- forced manual upgrades
- Terraform state drift
- completely blocked infrastructure workflows



### Type of Change

- [x] Azure Verified Module updates:
- [x] Bugfix containing backwards compatible bug fixes


### Checklist

- [x] Changes tested via fork in real deployment scenario
- [x] Fix resolves the issue without breaking existing functionality


Happy to adjust the approach if needed.
