### PR TITLE
feat: allow default agent pool to be managed as an independent child resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.11)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.4)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.46.0, < 5.0.0)
 
@@ -24,7 +24,6 @@ The following resources are used by this module:
 - [azapi_resource.this](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
 - [azapi_resource_action.this_admin_kubeconfig](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource_action) (resource)
 - [azapi_resource_action.this_user_kubeconfig](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource_action) (resource)
-- [azapi_update_resource.default_agent_pool](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/update_resource) (resource)
 - [azurerm_management_lock.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_lock) (resource)
 - [azurerm_monitor_diagnostic_setting.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) (resource)
 - [azurerm_private_endpoint.this_managed_dns_zone_groups](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) (resource)
@@ -988,6 +987,29 @@ object({
 ```
 
 Default: `{}`
+
+### <a name="input_default_agent_pool_managed_as_child"></a> [default\_agent\_pool\_managed\_as\_child](#input\_default\_agent\_pool\_managed\_as\_child)
+
+Description: Controls whether the default (system) agent pool is managed as an independent child resource after cluster creation.
+
+- When `false` (the default) the default agent pool is specified in the parent cluster's initial PUT and drift on `agentPoolProfiles` is ignored thereafter. Changes to the default agent pool (e.g. `vm_size`) that require replacement of the node pool cannot be applied without recreating the cluster.
+- When `true`, the default agent pool is imported into a dedicated child `azapi_resource` on the next apply and gets `create_before_destroy` semantics. Subsequent changes to immutable fields on the default agent pool (such as `vm_size`) will replace the pool in-place without cluster replacement. The replacement pool is created with a name suffixed by a short hash (e.g. `default1a2b`) so the old and new pools coexist during the swap. When Terraform then deletes the old pool, AKS cordons and drains its nodes, and the Kubernetes scheduler reschedules pods onto the new pool -- subject to `PodDisruptionBudget` settings on the workloads. A second `mode = "System"` pool is not required for the CBD swap itself, but may be useful for extra scheduling headroom or for workloads with strict PDBs.
+
+When `default_agent_pool_managed_as_child = true`, `default_agent_pool.name` must be 1-8 characters long to leave room for the 4-character hash suffix used during `create_before_destroy` replacement.
+
+Recommended migration flow for existing clusters:  
+1. Upgrade to this module version with `default_agent_pool_managed_as_child = false`.  
+2. On a subsequent apply, flip the value to `true`. This triggers a one-shot Terraform `import` that adopts the existing default pool into the child resource without any changes in Azure.
+
+> IMPORTANT: This variable must only be set to `true` on an apply where the cluster **already exists in Azure**. Setting it to `true` on the first-ever apply of the module would attempt to create the child agent pool resource concurrently with the cluster and fail, because the Azure API requires the cluster to exist before an agent pool can be PUT to it. Always do an initial apply with `default_agent_pool_managed_as_child = false`, then flip it to `true` on a subsequent apply.
+
+> DESTROY: When destroying the cluster, Terraform destroys the cluster resource first (enforced by an explicit `depends_on`). Azure deletes all agent pools as part of the cluster delete, so the subsequent child agent pool DELETE issued by Terraform returns 404 and is treated as already-deleted. `terraform destroy` therefore works without any extra steps.
+
+> WARNING: Flipping this variable back to `false` after it has been set to `true` will plan a standalone destroy of the adopted default agent pool. Azure will reject that delete if it is the only agent pool on the cluster ("There has to be at least one agent pool"). To reverse the adoption safely, either (a) first add a second user-mode agent pool via `node_pools`, or (b) use a `removed {}` block to detach the resource from Terraform state without deleting it in Azure.
+
+Type: `bool`
+
+Default: `false`
 
 ### <a name="input_diagnostic_settings"></a> [diagnostic\_settings](#input\_diagnostic\_settings)
 
@@ -2055,11 +2077,11 @@ Description: The FQDN of the master pool.
 
 ### <a name="output_identity_principal_id"></a> [identity\_principal\_id](#output\_identity\_principal\_id)
 
-Description: The principal id of the system assigned identity which is used by master components.
+Description: The principal id of the assigned identity which is used by master components.
 
 ### <a name="output_identity_tenant_id"></a> [identity\_tenant\_id](#output\_identity\_tenant\_id)
 
-Description: The tenant id of the system assigned identity which is used by master components.
+Description: The tenant id of the assigned identity which is used by master components.
 
 ### <a name="output_ingress_profile_web_app_routing_identity"></a> [ingress\_profile\_web\_app\_routing\_identity](#output\_ingress\_profile\_web\_app\_routing\_identity)
 
@@ -2124,6 +2146,12 @@ The following Modules are called:
 ### <a name="module_alerting"></a> [alerting](#module\_alerting)
 
 Source: ./modules/alerting
+
+Version:
+
+### <a name="module_default_agent_pool"></a> [default\_agent\_pool](#module\_default\_agent\_pool)
+
+Source: ./modules/agentpool
 
 Version:
 

--- a/main.default_agent_pool.tf
+++ b/main.default_agent_pool.tf
@@ -54,19 +54,100 @@ module "default_agent_pool_data" {
   workload_runtime              = var.default_agent_pool.workload_runtime
 }
 
-# This is in place so we can update the default agent pool, as we ignore changes to the object array in the parent resource.
-# TODO: Remove this when <https://github.com/Azure/terraform-provider-azapi/pull/1033> is merged and released.
-resource "azapi_update_resource" "default_agent_pool" {
-  name      = module.default_agent_pool_data.name
-  parent_id = azapi_resource.this.id
-  type      = "Microsoft.ContainerService/managedClusters/agentpools@2025-10-01"
-  body = {
-    properties = { for k, v in module.default_agent_pool_data.body_properties : k => v if v != null }
-  }
-  locks = [
-    azapi_resource.this.id,
-  ]
-  read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  response_export_values = []
-  update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+# When var.default_agent_pool_managed_as_child is true, the default agent pool is managed
+# as an independent child resource using the same create_before_destroy pattern as user
+# pools. The first apply after flipping the flag adopts the existing default pool via the
+# import block below without making any changes in Azure.
+#
+# On replacement of immutable fields (e.g. vm_size):
+#   1. A new pool is created with a name like "<name><4-char-hash>" (e.g. "default1a2b").
+#   2. AKS then deletes the old pool, which cordons and drains its nodes. The Kubernetes
+#      scheduler reschedules workloads onto the new pool subject to any PodDisruptionBudget
+#      settings. A second mode = "System" pool is not required for the swap itself.
+#
+# The parent cluster resource keeps `ignore_changes = [body.properties.agentPoolProfiles]`
+# so drift on the default pool (now owned by this module) does not cause the parent to
+# reconcile it.
+module "default_agent_pool" {
+  source = "./modules/agentpool"
+  count  = var.default_agent_pool_managed_as_child ? 1 : 0
+
+  name = var.default_agent_pool.name
+  # parent_id is built from inputs (not a reference to azapi_resource.this.id) so there is
+  # no implicit Terraform dependency from this module to the cluster resource. That lets us
+  # add an explicit depends_on on the cluster resource (see main.tf) so that on destroy the
+  # cluster is destroyed BEFORE this child pool resource. When the cluster is gone, the
+  # subsequent pool DELETE returns 404 and azapi treats that as already-deleted.
+  #
+  # Create-order note: on the initial apply with the flag=true-from-the-start the child
+  # pool resource PUT would race the cluster PUT. The module documents that the flag should
+  # only be flipped to true on an apply AFTER the cluster already exists (flag=false first
+  # apply, then flag=true on a subsequent apply). In that flow the import block adopts the
+  # existing pool and no server-side PUT happens for this resource.
+  parent_id                     = "${var.parent_id}/providers/Microsoft.ContainerService/managedClusters/${var.name}"
+  availability_zones            = var.default_agent_pool.availability_zones
+  capacity_reservation_group_id = var.default_agent_pool.capacity_reservation_group_id
+  count_of                      = var.default_agent_pool.count_of
+  create_before_destroy         = true
+  creation_data                 = var.default_agent_pool.creation_data
+  enable_auto_scaling           = var.default_agent_pool.enable_auto_scaling
+  enable_encryption_at_host     = var.default_agent_pool.enable_encryption_at_host
+  enable_fips                   = var.default_agent_pool.enable_fips
+  enable_node_public_ip         = var.default_agent_pool.enable_node_public_ip
+  enable_ultra_ssd              = var.default_agent_pool.enable_ultra_ssd
+  gateway_profile               = var.default_agent_pool.gateway_profile
+  gpu_instance_profile          = var.default_agent_pool.gpu_instance_profile
+  gpu_profile                   = var.default_agent_pool.gpu_profile
+  host_group_id                 = var.default_agent_pool.host_group_id
+  kubelet_config                = var.default_agent_pool.kubelet_config
+  kubelet_disk_type             = var.default_agent_pool.kubelet_disk_type
+  linux_os_config               = var.default_agent_pool.linux_os_config
+  local_dns_profile             = var.default_agent_pool.local_dns_profile
+  max_count                     = var.default_agent_pool.max_count
+  max_pods                      = var.default_agent_pool.max_pods
+  message_of_the_day            = var.default_agent_pool.message_of_the_day
+  min_count                     = var.default_agent_pool.min_count
+  mode                          = "System"
+  network_profile               = var.default_agent_pool.network_profile
+  node_labels                   = var.default_agent_pool.node_labels
+  node_public_ip_prefix_id      = var.default_agent_pool.node_public_ip_prefix_id
+  node_taints                   = var.default_agent_pool.node_taints
+  orchestrator_version          = var.default_agent_pool.orchestrator_version
+  os_disk_size_gb               = var.default_agent_pool.os_disk_size_gb
+  os_disk_type                  = var.default_agent_pool.os_disk_type
+  os_sku                        = var.default_agent_pool.os_sku
+  os_type                       = "Linux"
+  output_data_only              = false
+  pod_ip_allocation_mode        = var.default_agent_pool.pod_ip_allocation_mode
+  pod_subnet_id                 = var.default_agent_pool.pod_subnet_id
+  proximity_placement_group_id  = var.default_agent_pool.proximity_placement_group_id
+  scale_down_mode               = var.default_agent_pool.scale_down_mode
+  scale_set_eviction_policy     = var.default_agent_pool.scale_set_eviction_policy
+  scale_set_priority            = var.default_agent_pool.scale_set_priority
+  security_profile              = var.default_agent_pool.security_profile
+  spot_max_price                = var.default_agent_pool.spot_max_price
+  tags                          = var.tags
+  timeouts                      = var.agentpool_timeouts
+  type                          = var.default_agent_pool.type
+  upgrade_settings              = var.default_agent_pool.upgrade_settings
+  virtual_machines_profile      = var.default_agent_pool.virtual_machines_profile
+  vm_size                       = var.default_agent_pool.vm_size
+  vnet_subnet_id                = var.default_agent_pool.vnet_subnet_id
+  windows_profile               = var.default_agent_pool.windows_profile
+  workload_runtime              = var.default_agent_pool.workload_runtime
+}
+
+# Conditional import: adopts the existing default agent pool (created as part of the parent
+# cluster PUT) into the child module's create_before_destroy resource instance the first
+# time default_agent_pool_managed_as_child is set to true. Import blocks are idempotent --
+# on subsequent plans Terraform sees the resource already in state and this is a no-op.
+#
+# The import id is constructed from known-at-plan-time inputs (var.parent_id, var.name,
+# var.default_agent_pool.name) rather than from azapi_resource.this.id, because Terraform
+# requires the import id to be fully known during plan. This means the adopted name must
+# match the original default pool name used in the parent cluster PUT.
+import {
+  for_each = var.default_agent_pool_managed_as_child ? toset(["default"]) : toset([])
+  to       = module.default_agent_pool[0].azapi_resource.this_create_before_destroy[0]
+  id       = "${var.parent_id}/providers/Microsoft.ContainerService/managedClusters/${var.name}/agentPools/${var.default_agent_pool.name}"
 }

--- a/main.tf
+++ b/main.tf
@@ -51,8 +51,18 @@ resource "azapi_resource" "this" {
     }
   }
 
+  # When default_agent_pool_managed_as_child is true, the child pool resource's parent_id
+  # is built from inputs (see main.default_agent_pool.tf) rather than a reference to this
+  # resource's id, so there is no implicit create/destroy dependency between the two. This
+  # explicit depends_on makes destroy order deterministic: Terraform destroys dependents
+  # first, so the cluster is destroyed BEFORE the child pool. After the cluster is gone
+  # the child pool DELETE returns 404, which azapi treats as already-deleted. This avoids
+  # Azure's "There has to be at least one agent pool" 400 error that would otherwise occur
+  # when Terraform tries to delete the sole remaining agent pool while the cluster still
+  # exists.
+  depends_on = [module.default_agent_pool]
+
   lifecycle {
-    # TODO: When https://github.com/Azure/terraform-provider-azapi/pull/1033 is merged, we can remove this.
     ignore_changes = [
       body.properties.kubernetesVersion,
       body.properties.agentPoolProfiles,

--- a/terraform.tf
+++ b/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.4"
+      version = "~> 2.9"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/tests/integration/default_agent_pool_managed_as_child.tftest.hcl
+++ b/tests/integration/default_agent_pool_managed_as_child.tftest.hcl
@@ -1,0 +1,145 @@
+# Integration test proving the default_agent_pool_managed_as_child migration flow works
+# end-to-end against real Azure infrastructure.
+#
+# Flow covered:
+#   1. setup                                -- creates a resource group via the helper module.
+#   2. create_with_flag_false               -- deploys a minimal AKS cluster with the default
+#                                              agent pool embedded in the parent cluster PUT
+#                                              (default_agent_pool_managed_as_child = false).
+#   3. flip_flag_to_true_imports_pool       -- re-applies with the flag flipped to true. This
+#                                              triggers the one-shot Terraform `import` block
+#                                              that adopts the existing default agent pool
+#                                              into the child module. No changes should be made
+#                                              in Azure -- the adopted pool keeps its original
+#                                              name and spec.
+#   4. change_vm_size_replaces_pool         -- changes the default pool vm_size. The child
+#                                              resource's create_before_destroy semantics create
+#                                              a new pool with a suffixed name, AKS drains the
+#                                              old pool, then Terraform deletes it. At the end
+#                                              the child module reports a Succeeded provisioning
+#                                              state on the new pool with the new vm_size.
+
+# Common inputs shared across the three apply runs below. Each run overrides only what it needs
+# to vary (the managed-as-child flag and the default_agent_pool vm_size).
+variables {
+  location  = "eastus"
+  parent_id = ""
+  default_agent_pool = {
+    name     = "default"
+    vm_size  = "Standard_DS2_v2"
+    count_of = 1
+  }
+  managed_identities = {
+    system_assigned = true
+  }
+  dns_prefix = "defaultitest"
+}
+
+provider "azurerm" {
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
+run "setup" {
+  module {
+    source = "./tests/integration/setup"
+  }
+}
+
+run "create_with_flag_false" {
+  command = apply
+
+  variables {
+    location                            = run.setup.resource_group_location
+    name                                = run.setup.cluster_name
+    parent_id                           = run.setup.resource_group_id
+    default_agent_pool_managed_as_child = false
+  }
+
+  assert {
+    condition     = azapi_resource.this.id != ""
+    error_message = "Cluster resource must be created with a valid id."
+  }
+
+  assert {
+    condition     = length(module.default_agent_pool) == 0
+    error_message = "Child default_agent_pool module must not be instantiated when the flag is false."
+  }
+
+  # The parent body is the source of truth for what was PUT to Azure on initial create.
+  assert {
+    condition = anytrue([
+      for pool in azapi_resource.this.body.properties.agentPoolProfiles :
+      pool.name == "default" && lower(pool.vmSize) == lower("Standard_DS2_v2")
+    ])
+    error_message = "Parent cluster body must include a 'default' agent pool with vm_size Standard_DS2_v2."
+  }
+}
+
+run "flip_flag_to_true_imports_pool" {
+  command = apply
+
+  variables {
+    location                            = run.setup.resource_group_location
+    name                                = run.setup.cluster_name
+    parent_id                           = run.setup.resource_group_id
+    default_agent_pool_managed_as_child = true
+  }
+
+  # The pool must be adopted into the child module at its original name.
+  assert {
+    condition     = length(module.default_agent_pool) == 1
+    error_message = "Child default_agent_pool module must be instantiated when the flag is true."
+  }
+
+  assert {
+    condition     = module.default_agent_pool[0].name == "default"
+    error_message = "Adopted default agent pool must retain its original name after import (got: ${module.default_agent_pool[0].name})."
+  }
+
+  assert {
+    condition     = module.default_agent_pool[0].provisioning_state == "Succeeded"
+    error_message = "Adopted default agent pool must report Succeeded provisioning state."
+  }
+
+  # resource_id is populated only for non-data-only child modules.
+  assert {
+    condition     = module.default_agent_pool[0].resource_id != null && module.default_agent_pool[0].resource_id != ""
+    error_message = "Adopted default agent pool must have a non-empty resource_id after import."
+  }
+}
+
+run "change_vm_size_replaces_pool" {
+  command = apply
+
+  variables {
+    location                            = run.setup.resource_group_location
+    name                                = run.setup.cluster_name
+    parent_id                           = run.setup.resource_group_id
+    default_agent_pool_managed_as_child = true
+    default_agent_pool = {
+      name     = "default"
+      vm_size  = "Standard_DS3_v2" # changed from Standard_DS2_v2
+      count_of = 1
+    }
+  }
+
+  # After CBD replacement the pool's name is suffixed with a 4-char hash.
+  assert {
+    condition     = startswith(module.default_agent_pool[0].name, "default") && length(module.default_agent_pool[0].name) == 11
+    error_message = "Replaced default agent pool must have a hash-suffixed name of the form 'default<4hex>' (got: ${module.default_agent_pool[0].name})."
+  }
+
+  assert {
+    condition     = module.default_agent_pool[0].name != "default"
+    error_message = "Replaced default agent pool must not retain the original name 'default'."
+  }
+
+  assert {
+    condition     = module.default_agent_pool[0].provisioning_state == "Succeeded"
+    error_message = "Replaced default agent pool must report Succeeded provisioning state."
+  }
+}

--- a/tests/integration/setup/main.tf
+++ b/tests/integration/setup/main.tf
@@ -1,0 +1,56 @@
+terraform {
+  required_version = ">= 1.9, < 2.0"
+
+  required_providers {
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~> 2.9"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+}
+
+provider "azapi" {}
+
+module "regions" {
+  source  = "Azure/avm-utl-regions/azurerm"
+  version = "0.11.0"
+
+  is_recommended         = true
+  region_name_regex      = "euap"
+  region_name_regex_mode = "not_match"
+}
+
+resource "random_integer" "region_index" {
+  max = length(module.regions.regions) - 1
+  min = 0
+}
+
+module "naming" {
+  source  = "Azure/naming/azurerm"
+  version = "0.4.2"
+}
+
+data "azapi_client_config" "current" {}
+
+resource "azapi_resource" "resource_group" {
+  location  = module.regions.regions[random_integer.region_index.result].name
+  name      = module.naming.resource_group.name_unique
+  parent_id = "/subscriptions/${data.azapi_client_config.current.subscription_id}"
+  type      = "Microsoft.Resources/resourceGroups@2021-04-01"
+}
+
+output "resource_group_id" {
+  value = azapi_resource.resource_group.id
+}
+
+output "resource_group_location" {
+  value = azapi_resource.resource_group.location
+}
+
+output "cluster_name" {
+  value = module.naming.kubernetes_cluster.name_unique
+}

--- a/tests/unit/default_agent_pool_managed_as_child.tftest.hcl
+++ b/tests/unit/default_agent_pool_managed_as_child.tftest.hcl
@@ -1,0 +1,39 @@
+mock_provider "azapi" {}
+mock_provider "azurerm" {}
+mock_provider "modtm" {}
+mock_provider "random" {}
+
+variables {
+  location  = "eastus"
+  name      = "test-aks"
+  parent_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test"
+}
+
+# When the flag is false, the child module for the default agent pool is not instantiated.
+run "default_agent_pool_child_not_instantiated_when_flag_false" {
+  command = plan
+
+  assert {
+    condition     = length(module.default_agent_pool) == 0
+    error_message = "module.default_agent_pool must have count 0 when default_agent_pool_managed_as_child is false."
+  }
+}
+
+# Validation rejects a default agent pool name longer than 8 characters when the flag is
+# true, because the create_before_destroy rename pattern appends a 4-character suffix and
+# the Azure node-pool name limit is 12 characters.
+run "default_agent_pool_name_too_long_rejected_when_managed_as_child" {
+  command = plan
+
+  variables {
+    default_agent_pool_managed_as_child = true
+    default_agent_pool = {
+      name    = "toolongname"
+      vm_size = "Standard_D2ds_v5"
+    }
+  }
+
+  expect_failures = [
+    var.default_agent_pool_managed_as_child,
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -507,6 +507,8 @@ variable "default_agent_pool" {
 Configuration block for the default agent pool of the Kubernetes cluster.
 See `var.agent_pools` for details on the available options.
 
+NOTE: Updates to the default agent pool post-deployment require `default_agent_pool_managed_as_child = true`. See that variable for details and recommended migration steps for existing clusters.
+
 Note that:
 - The `os_type` and `mode` options are not available here and are automatically set to `Linux` and `System` respectively.
 - The default node count (`count_of`) is set to `3` if not specified.
@@ -514,6 +516,35 @@ Note that:
 - It is not supported to rename the default agent pool after creation.
 DESCRIPTION
   nullable    = false
+}
+
+variable "default_agent_pool_managed_as_child" {
+  type        = bool
+  default     = false
+  description = <<DESCRIPTION
+Controls whether the default (system) agent pool is managed as an independent child resource after cluster creation.
+
+- When `false` (the default) the default agent pool is specified in the parent cluster's initial PUT and drift on `agentPoolProfiles` is ignored thereafter. Changes to the default agent pool (e.g. `vm_size`) that require replacement of the node pool cannot be applied without recreating the cluster.
+- When `true`, the default agent pool is imported into a dedicated child `azapi_resource` on the next apply and gets `create_before_destroy` semantics. Subsequent changes to immutable fields on the default agent pool (such as `vm_size`) will replace the pool in-place without cluster replacement. The replacement pool is created with a name suffixed by a short hash (e.g. `default1a2b`) so the old and new pools coexist during the swap. When Terraform then deletes the old pool, AKS cordons and drains its nodes, and the Kubernetes scheduler reschedules pods onto the new pool -- subject to `PodDisruptionBudget` settings on the workloads. A second `mode = "System"` pool is not required for the CBD swap itself, but may be useful for extra scheduling headroom or for workloads with strict PDBs.
+
+When `default_agent_pool_managed_as_child = true`, `default_agent_pool.name` must be 1-8 characters long to leave room for the 4-character hash suffix used during `create_before_destroy` replacement.
+
+Recommended migration flow for existing clusters:
+1. Upgrade to this module version with `default_agent_pool_managed_as_child = false`.
+2. On a subsequent apply, flip the value to `true`. This triggers a one-shot Terraform `import` that adopts the existing default pool into the child resource without any changes in Azure.
+
+> IMPORTANT: This variable must only be set to `true` on an apply where the cluster **already exists in Azure**. Setting it to `true` on the first-ever apply of the module would attempt to create the child agent pool resource concurrently with the cluster and fail, because the Azure API requires the cluster to exist before an agent pool can be PUT to it. Always do an initial apply with `default_agent_pool_managed_as_child = false`, then flip it to `true` on a subsequent apply.
+
+> DESTROY: When destroying the cluster, Terraform destroys the cluster resource first (enforced by an explicit `depends_on`). Azure deletes all agent pools as part of the cluster delete, so the subsequent child agent pool DELETE issued by Terraform returns 404 and is treated as already-deleted. `terraform destroy` therefore works without any extra steps.
+
+> WARNING: Flipping this variable back to `false` after it has been set to `true` will plan a standalone destroy of the adopted default agent pool. Azure will reject that delete if it is the only agent pool on the cluster ("There has to be at least one agent pool"). To reverse the adoption safely, either (a) first add a second user-mode agent pool via `node_pools`, or (b) use a `removed {}` block to detach the resource from Terraform state without deleting it in Azure.
+DESCRIPTION
+  nullable    = false
+
+  validation {
+    condition     = !var.default_agent_pool_managed_as_child || length(var.default_agent_pool.name) <= 8
+    error_message = "When `default_agent_pool_managed_as_child` is true, `default_agent_pool.name` must be 1-8 characters long to leave room for the 4-character hash suffix used during create_before_destroy replacement."
+  }
 }
 
 variable "diagnostic_settings" {


### PR DESCRIPTION
## Summary

- Adds `default_agent_pool_managed_as_child` (default `false`). When flipped to `true` on a subsequent apply, the module adopts the existing default agent pool into the same `./modules/agentpool` child module used for user pools, gaining `create_before_destroy` semantics.
- Lets users change immutable fields on the default agent pool (e.g. `vm_size`, `os_disk_type`) without recreating the cluster. A replacement pool with a 4-char hash suffix (e.g. `default1a2b`) is created first; AKS drains the old pool; Terraform deletes it.
- `terraform destroy` works with no manual steps: an explicit `depends_on` forces the cluster to be destroyed before the child pool, and the follow-up pool DELETE 404s cleanly.

## Changes

- `variables.tf`: new `default_agent_pool_managed_as_child` variable with cross-variable validation (`default_agent_pool.name` must be ≤8 chars when the flag is true, to leave room for the hash suffix) and detailed documentation covering the migration flow, the "cluster must already exist" pre-condition, and destroy semantics.
- `main.default_agent_pool.tf`:
  - Keeps `module.default_agent_pool_data` (output-only) so the parent cluster PUT still includes `agentPoolProfiles`, satisfying Azure's cluster-create requirement.
  - Adds a count-gated `module.default_agent_pool` call that reuses the existing agentpool submodule with `create_before_destroy = true`.
  - Builds `parent_id` from inputs (`"${var.parent_id}/.../managedClusters/${var.name}"`) rather than referencing `azapi_resource.this.id`, so there is no implicit reference-based dependency between the cluster resource and the child pool resource.
  - Adds a conditional `import` block (`for_each = var.default_agent_pool_managed_as_child ? toset(["default"]) : toset([])`) that adopts the existing default pool the first time the flag is set to `true`. Idempotent on subsequent applies.
  - Removes the previous `azapi_update_resource.default_agent_pool` workaround.
- `main.tf`: adds `depends_on = [module.default_agent_pool]` on `azapi_resource.this` so destroy order is cluster-first-then-pool. The subsequent pool DELETE hits 404 and azapi treats it as already-deleted, avoiding Azure's "There has to be at least one agent pool" 400.
- `terraform.tf`: bumps `azapi` constraint from `~> 2.4` to `~> 2.9`.
- `README.md`: regenerated to reflect the new variable.
- `tests/unit/default_agent_pool_managed_as_child.tftest.hcl`: new unit tests covering both flag states and the name-length validation.
- `tests/integration/default_agent_pool_managed_as_child.tftest.hcl` + `tests/integration/setup/`: new integration test with three runs covering create-with-flag-false, flip-to-true/import, and vm_size-triggered CBD replacement.

## Verification

- `PORCH_NO_TUI=1 ./avm tf-test-unit` — pass.
- `PORCH_NO_TUI=1 ./avm tf-test-integration` against real Azure (~13 min) — all three runs pass, teardown destroys cleanly:
  - `create_with_flag_false` — cluster deploys with default pool embedded in parent PUT.
  - `flip_flag_to_true_imports_pool` — child module adopts existing pool; no Azure change.
  - `change_vm_size_replaces_pool` — new `default<hash>` pool created, old `default` removed, new pool reports `Succeeded`.
- `PORCH_NO_TUI=1 ./avm pre-commit` — clean for all files touched in this PR. The pre-existing unrelated `nodepool/_header.md: no such file or directory` docs-generation error is present on `main` as well and is unrelated to this change.

## Notes

- **Pre-condition for enabling the flag**: `default_agent_pool_managed_as_child = true` must only be set on an apply where the cluster already exists in Azure. Setting it on the first-ever apply would race the cluster PUT with the child pool PUT and fail. The recommended flow (initial apply with flag=false, subsequent apply with flag=true) is documented on the variable.
- **Reverse flip**: flipping the flag back to `false` while the cluster still exists will plan a standalone destroy of the adopted pool and be rejected by Azure if it is the only pool. The variable description explains the two escape hatches (`removed {}` block, or add a second pool first).
- **Follow-up**: `body.properties.kubernetesVersion` is still in the parent resource's `lifecycle.ignore_changes`, so changes to `var.kubernetes_version` are silently dropped. An `azapi_update_resource` side-car for kubernetes_version is tracked as a separate follow-up.

Closes #177