### PR TITLE
fix: handle null values in node_provisioning_profile and node_resource_group_profile validation

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -954,11 +954,11 @@ The nodeProvisioningProfile of the resource.
 DESCRIPTION
 
   validation {
-    condition     = var.node_provisioning_profile == null || var.node_provisioning_profile.default_node_pools == null || contains(["Auto", "None"], var.node_provisioning_profile.default_node_pools)
+    condition     = var.node_provisioning_profile == null || try(var.node_provisioning_profile.default_node_pools, null) == null || contains(["Auto", "None"], try(var.node_provisioning_profile.default_node_pools, ""))
     error_message = "node_provisioning_profile.default_node_pools must be one of: [\"Auto\", \"None\"]."
   }
   validation {
-    condition     = var.node_provisioning_profile == null || var.node_provisioning_profile.mode == null || contains(["Auto", "Manual"], var.node_provisioning_profile.mode)
+    condition     = var.node_provisioning_profile == null || try(var.node_provisioning_profile.mode, null) == null || contains(["Auto", "Manual"], try(var.node_provisioning_profile.mode, ""))
     error_message = "node_provisioning_profile.mode must be one of: [\"Auto\", \"Manual\"]."
   }
 }
@@ -984,7 +984,7 @@ Node resource group lockdown profile for a managed cluster.
 DESCRIPTION
 
   validation {
-    condition     = var.node_resource_group_profile == null || var.node_resource_group_profile.restriction_level == null || contains(["ReadOnly", "Unrestricted"], var.node_resource_group_profile.restriction_level)
+    condition     = var.node_resource_group_profile == null || try(var.node_resource_group_profile.restriction_level, null) == null || contains(["ReadOnly", "Unrestricted"], try(var.node_resource_group_profile.restriction_level, ""))
     error_message = "node_resource_group_profile.restriction_level must be one of: [\"ReadOnly\", \"Unrestricted\"]."
   }
 }


### PR DESCRIPTION
## Description

Fixes `Attempt to get attribute from null value` error during `terraform plan` when `node_provisioning_profile` or `node_resource_group_profile` variables are left as their default `null` value.

## Root Cause

Terraform's `validation` block does not short-circuit boolean expressions like programming languages do. Even when the first condition `var.node_provisioning_profile == null` evaluates to `true`, Terraform still attempts to evaluate `var.node_provisioning_profile.mode`, which crashes on the null object.

## Error Reproduced (Before Fix)

\`\`\`
Error: Attempt to get attribute from null value

  on .terraform/modules/aks/variables.tf line 961, in variable "node_provisioning_profile":
   961:     condition = var.node_provisioning_profile == null || var.node_provisioning_profile.mode == null || contains(["Auto", "Manual"], var.node_provisioning_profile.mode)
    |----------------
    | var.node_provisioning_profile is null
    | This value is null, so it does not have any attributes.

Error: Attempt to get attribute from null value

  on .terraform/modules/aks/variables.tf line 987, in variable "node_resource_group_profile":
   987:     condition = var.node_resource_group_profile == null || var.node_resource_group_profile.restriction_level == null || ...
    |----------------
    | var.node_resource_group_profile is null
    | This value is null, so it does not have any attributes.
\`\`\`

## Fix

Wrapped attribute accesses inside `try()` so they safely return `null` when the parent object is `null`, while preserving the validation intent for non-null inputs.

Changes applied to three validation blocks in `variables.tf`:
- `node_provisioning_profile.default_node_pools` (line ~957)
- `node_provisioning_profile.mode` (line ~961)
- `node_resource_group_profile.restriction_level` (line ~987)

## Testing

- ✅ `node_provisioning_profile = null` → no error (previously failed)
- ✅ `node_provisioning_profile = { mode = "Auto" }` → passes validation
- ✅ `node_provisioning_profile = { mode = "Invalid" }` → correctly rejected with error message
- ✅ Same scenarios verified for `node_resource_group_profile`

## Checklist

- [x] `terraform fmt` applied
- [x] No breaking changes — fix is fully backward compatible
- [x] Existing validation logic preserved for non-null inputs