### PR TITLE
Fix null-safe validations for optional AKS inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2055,11 +2055,11 @@ Description: The FQDN of the master pool.
 
 ### <a name="output_identity_principal_id"></a> [identity\_principal\_id](#output\_identity\_principal\_id)
 
-Description: The principal id of the system assigned identity which is used by master components.
+Description: The principal id of the assigned identity which is used by master components.
 
 ### <a name="output_identity_tenant_id"></a> [identity\_tenant\_id](#output\_identity\_tenant\_id)
 
-Description: The tenant id of the system assigned identity which is used by master components.
+Description: The tenant id of the assigned identity which is used by master components.
 
 ### <a name="output_ingress_profile_web_app_routing_identity"></a> [ingress\_profile\_web\_app\_routing\_identity](#output\_ingress\_profile\_web\_app\_routing\_identity)
 

--- a/avm
+++ b/avm
@@ -173,6 +173,15 @@ if [ -f "avm.config.json" ]; then
   done
 fi
 
+# Forward AVM_BARE_* environment variables to the container with the prefix stripped
+while IFS='=' read -r bareKey bareValue; do
+  [ -z "$bareKey" ] && continue
+  strippedKey="${bareKey#AVM_BARE_}"
+  export "$strippedKey"="$bareValue"
+  LOCAL_ENVIRONMENT_VARIABLES="${LOCAL_ENVIRONMENT_VARIABLES}-e $strippedKey "
+  echo "Forwarding AVM bare variable to container as: $strippedKey"
+done < <(env | grep '^AVM_BARE_' || true)
+
 # Check if we are running in a container
 # If we are then just run make directly
 if [ -z "${AVM_IN_CONTAINER}" ]; then
@@ -199,7 +208,7 @@ if [ -z "${AVM_IN_CONTAINER}" ]; then
     -e TF_IN_AUTOMATION=1 \
     ${LOCAL_ENVIRONMENT_VARIABLES} \
     --env-file <(env | grep '^TF_VAR_') \
-    --env-file <(env | grep '^AVM_') \
+    --env-file <(env | grep '^AVM_' | grep -v '^AVM_BARE_') \
     "${CONTAINER_IMAGE}" \
     make \
     TUI="${TUI}" \

--- a/avm.ps1
+++ b/avm.ps1
@@ -150,9 +150,16 @@ if (-not $env:AVM_IN_CONTAINER) {
     $dockerArgs += @("-e", "$($_.Name)=$($_.Value)")
   }
 
-  # Add AVM_ environment variables
-  Get-ChildItem env: | Where-Object { $_.Name -like "AVM_*" } | ForEach-Object {
+  # Add AVM_ environment variables (excluding AVM_BARE_* which are forwarded with the prefix stripped)
+  Get-ChildItem env: | Where-Object { $_.Name -like "AVM_*" -and $_.Name -notlike "AVM_BARE_*" } | ForEach-Object {
     $dockerArgs += @("-e", "$($_.Name)=$($_.Value)")
+  }
+
+  # Forward AVM_BARE_* environment variables to the container with the prefix stripped
+  Get-ChildItem env: | Where-Object { $_.Name -like "AVM_BARE_*" } | ForEach-Object {
+    $strippedName = $_.Name -replace '^AVM_BARE_', ''
+    $dockerArgs += @("-e", "$strippedName=$($_.Value)")
+    Write-Host "Forwarding AVM bare variable to container as: $strippedName"
   }
 
   # Add local environment variables from avm.config.json

--- a/tests/unit/node_profiles.tftest.hcl
+++ b/tests/unit/node_profiles.tftest.hcl
@@ -1,0 +1,100 @@
+mock_provider "azapi" {}
+mock_provider "azurerm" {}
+mock_provider "modtm" {}
+mock_provider "random" {}
+
+variables {
+  location  = "eastus"
+  name      = "test-aks"
+  parent_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test"
+}
+
+run "null_node_profiles_are_omitted" {
+  command = plan
+
+  variables {
+    node_provisioning_profile   = null
+    node_resource_group_profile = null
+  }
+
+  assert {
+    condition     = !can(azapi_resource.this.body.properties.nodeProvisioningProfile)
+    error_message = "nodeProvisioningProfile should be omitted when node_provisioning_profile is null."
+  }
+
+  assert {
+    condition     = !can(azapi_resource.this.body.properties.nodeResourceGroupProfile)
+    error_message = "nodeResourceGroupProfile should be omitted when node_resource_group_profile is null."
+  }
+}
+
+run "valid_node_profiles_are_included" {
+  command = plan
+
+  variables {
+    node_provisioning_profile = {
+      default_node_pools = "None"
+      mode               = "Manual"
+    }
+    node_resource_group_profile = {
+      restriction_level = "ReadOnly"
+    }
+  }
+
+  assert {
+    condition     = azapi_resource.this.body.properties.nodeProvisioningProfile.defaultNodePools == "None"
+    error_message = "nodeProvisioningProfile.defaultNodePools should use the provided value."
+  }
+
+  assert {
+    condition     = azapi_resource.this.body.properties.nodeProvisioningProfile.mode == "Manual"
+    error_message = "nodeProvisioningProfile.mode should use the provided value."
+  }
+
+  assert {
+    condition     = azapi_resource.this.body.properties.nodeResourceGroupProfile.restrictionLevel == "ReadOnly"
+    error_message = "nodeResourceGroupProfile.restrictionLevel should use the provided value."
+  }
+}
+
+run "invalid_node_provisioning_default_node_pools_fails" {
+  command = plan
+
+  variables {
+    node_provisioning_profile = {
+      default_node_pools = "Invalid"
+    }
+  }
+
+  expect_failures = [
+    var.node_provisioning_profile,
+  ]
+}
+
+run "invalid_node_provisioning_mode_fails" {
+  command = plan
+
+  variables {
+    node_provisioning_profile = {
+      mode = "Invalid"
+    }
+  }
+
+  expect_failures = [
+    var.node_provisioning_profile,
+  ]
+}
+
+run "invalid_node_resource_group_restriction_level_fails" {
+  command = plan
+
+  variables {
+    node_resource_group_profile = {
+      restriction_level = "Invalid"
+    }
+  }
+
+  expect_failures = [
+    var.node_resource_group_profile,
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -954,11 +954,11 @@ The nodeProvisioningProfile of the resource.
 DESCRIPTION
 
   validation {
-    condition     = var.node_provisioning_profile == null || var.node_provisioning_profile.default_node_pools == null || contains(["Auto", "None"], var.node_provisioning_profile.default_node_pools)
+    condition     = var.node_provisioning_profile == null || try(var.node_provisioning_profile.default_node_pools, null) == null || contains(["Auto", "None"], try(var.node_provisioning_profile.default_node_pools, ""))
     error_message = "node_provisioning_profile.default_node_pools must be one of: [\"Auto\", \"None\"]."
   }
   validation {
-    condition     = var.node_provisioning_profile == null || var.node_provisioning_profile.mode == null || contains(["Auto", "Manual"], var.node_provisioning_profile.mode)
+    condition     = var.node_provisioning_profile == null || try(var.node_provisioning_profile.mode, null) == null || contains(["Auto", "Manual"], try(var.node_provisioning_profile.mode, ""))
     error_message = "node_provisioning_profile.mode must be one of: [\"Auto\", \"Manual\"]."
   }
 }
@@ -984,7 +984,7 @@ Node resource group lockdown profile for a managed cluster.
 DESCRIPTION
 
   validation {
-    condition     = var.node_resource_group_profile == null || var.node_resource_group_profile.restriction_level == null || contains(["ReadOnly", "Unrestricted"], var.node_resource_group_profile.restriction_level)
+    condition     = var.node_resource_group_profile == null || try(var.node_resource_group_profile.restriction_level, null) == null || contains(["ReadOnly", "Unrestricted"], try(var.node_resource_group_profile.restriction_level, ""))
     error_message = "node_resource_group_profile.restriction_level must be one of: [\"ReadOnly\", \"Unrestricted\"]."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -92,7 +92,7 @@ variable "addon_profile_ingress_application_gateway" {
 
   validation {
     error_message = "If addon_profile_ingress_application_gateway.enabled is true, then addon_profile_ingress_application_gateway.config.application_gateway_id must be set."
-    condition     = !(var.addon_profile_ingress_application_gateway != null && var.addon_profile_ingress_application_gateway.enabled == true && (var.addon_profile_ingress_application_gateway.config == null || var.addon_profile_ingress_application_gateway.config.application_gateway_id == ""))
+    condition     = !(try(var.addon_profile_ingress_application_gateway.enabled, false) == true && (try(var.addon_profile_ingress_application_gateway.config, null) == null || try(var.addon_profile_ingress_application_gateway.config.application_gateway_id, "") == ""))
   }
 }
 
@@ -121,7 +121,7 @@ variable "addon_profile_oms_agent" {
 
   validation {
     error_message = "If addon_profile_oms_agent.enabled is true, then addon_profile_oms_agent.config.log_analytics_workspace_resource_id must be set."
-    condition     = var.addon_profile_oms_agent == null || !(var.addon_profile_oms_agent.enabled == true && (var.addon_profile_oms_agent.config == null || var.addon_profile_oms_agent.config.log_analytics_workspace_resource_id == ""))
+    condition     = !(try(var.addon_profile_oms_agent.enabled, false) == true && (try(var.addon_profile_oms_agent.config, null) == null || try(var.addon_profile_oms_agent.config.log_analytics_workspace_resource_id, "") == ""))
   }
 }
 
@@ -248,7 +248,7 @@ Parameters to be applied to the cluster-autoscaler when enabled
 DESCRIPTION
 
   validation {
-    condition     = var.auto_scaler_profile == null || var.auto_scaler_profile.expander == null || contains(["least-waste", "most-pods", "priority", "random"], var.auto_scaler_profile.expander)
+    condition     = var.auto_scaler_profile == null || try(var.auto_scaler_profile.expander, null) == null || contains(["least-waste", "most-pods", "priority", "random"], coalesce(try(var.auto_scaler_profile.expander, null), ""))
     error_message = "auto_scaler_profile.expander must be one of: [\"least-waste\", \"most-pods\", \"priority\", \"random\"]."
   }
 }
@@ -268,11 +268,11 @@ Auto upgrade profile for a managed cluster.
 DESCRIPTION
 
   validation {
-    condition     = var.auto_upgrade_profile == null || var.auto_upgrade_profile.node_os_upgrade_channel == null || contains(["NodeImage", "None", "SecurityPatch", "Unmanaged"], var.auto_upgrade_profile.node_os_upgrade_channel)
+    condition     = var.auto_upgrade_profile == null || try(var.auto_upgrade_profile.node_os_upgrade_channel, null) == null || contains(["NodeImage", "None", "SecurityPatch", "Unmanaged"], coalesce(try(var.auto_upgrade_profile.node_os_upgrade_channel, null), ""))
     error_message = "auto_upgrade_profile.node_os_upgrade_channel must be one of: [\"NodeImage\", \"None\", \"SecurityPatch\", \"Unmanaged\"]."
   }
   validation {
-    condition     = var.auto_upgrade_profile == null || var.auto_upgrade_profile.upgrade_channel == null || contains(["node-image", "none", "patch", "rapid", "stable"], var.auto_upgrade_profile.upgrade_channel)
+    condition     = var.auto_upgrade_profile == null || try(var.auto_upgrade_profile.upgrade_channel, null) == null || contains(["node-image", "none", "patch", "rapid", "stable"], coalesce(try(var.auto_upgrade_profile.upgrade_channel, null), ""))
     error_message = "auto_upgrade_profile.upgrade_channel must be one of: [\"node-image\", \"none\", \"patch\", \"rapid\", \"stable\"]."
   }
 }
@@ -315,7 +315,7 @@ The bootstrap profile.
 DESCRIPTION
 
   validation {
-    condition     = var.bootstrap_profile == null || var.bootstrap_profile.artifact_source == null || contains(["Cache", "Direct"], var.bootstrap_profile.artifact_source)
+    condition     = var.bootstrap_profile == null || try(var.bootstrap_profile.artifact_source, null) == null || contains(["Cache", "Direct"], coalesce(try(var.bootstrap_profile.artifact_source, null), ""))
     error_message = "bootstrap_profile.artifact_source must be one of: [\"Cache\", \"Direct\"]."
   }
 }
@@ -623,7 +623,7 @@ The complex type of the extended location.
 DESCRIPTION
 
   validation {
-    condition     = var.extended_location == null || var.extended_location.type == null || contains(["EdgeZone"], var.extended_location.type)
+    condition     = var.extended_location == null || try(var.extended_location.type, null) == null || contains(["EdgeZone"], coalesce(try(var.extended_location.type, null), ""))
     error_message = "extended_location.type must be one of: [\"EdgeZone\"]."
   }
 }
@@ -672,11 +672,11 @@ DESCRIPTION
 
   validation {
     error_message = "The only accepted key for identity_profile is 'kubeletidentity'."
-    condition     = var.identity_profile == null || alltrue([for k in keys(var.identity_profile) : k == "kubeletidentity"])
+    condition     = var.identity_profile == null || alltrue([for k in try(keys(var.identity_profile), []) : k == "kubeletidentity"])
   }
   validation {
     error_message = "When kublet identity is specified in identity_profile, managed_identities.user_assigned_resource_ids must be configured."
-    condition     = var.identity_profile == null || !contains(keys(var.identity_profile), "kubeletidentity") || (var.managed_identities != null && length(var.managed_identities.user_assigned_resource_ids) == 1)
+    condition     = var.identity_profile == null || !contains(try(keys(var.identity_profile), []), "kubeletidentity") || length(var.managed_identities.user_assigned_resource_ids) == 1
   }
 }
 
@@ -898,43 +898,43 @@ Profile of network configuration.
 DESCRIPTION
 
   validation {
-    condition     = var.network_profile == null || var.network_profile.dns_service_ip == null || can(regex("^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$", var.network_profile.dns_service_ip))
+    condition     = var.network_profile == null || try(var.network_profile.dns_service_ip, null) == null || can(regex("^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$", coalesce(try(var.network_profile.dns_service_ip, null), "")))
     error_message = "network_profile.dns_service_ip must match the pattern: ^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$."
   }
   validation {
-    condition     = var.network_profile == null || var.network_profile.load_balancer_sku == null || contains(["basic", "standard"], var.network_profile.load_balancer_sku)
+    condition     = var.network_profile == null || try(var.network_profile.load_balancer_sku, null) == null || contains(["basic", "standard"], coalesce(try(var.network_profile.load_balancer_sku, null), ""))
     error_message = "network_profile.load_balancer_sku must be one of: [\"basic\", \"standard\"]."
   }
   validation {
-    condition     = var.network_profile == null || var.network_profile.network_dataplane == null || contains(["azure", "cilium"], var.network_profile.network_dataplane)
+    condition     = var.network_profile == null || try(var.network_profile.network_dataplane, null) == null || contains(["azure", "cilium"], coalesce(try(var.network_profile.network_dataplane, null), ""))
     error_message = "network_profile.network_dataplane must be one of: [\"azure\", \"cilium\"]."
   }
   validation {
-    condition     = var.network_profile == null || var.network_profile.network_mode == null || contains(["bridge", "transparent"], var.network_profile.network_mode)
+    condition     = var.network_profile == null || try(var.network_profile.network_mode, null) == null || contains(["bridge", "transparent"], coalesce(try(var.network_profile.network_mode, null), ""))
     error_message = "network_profile.network_mode must be one of: [\"bridge\", \"transparent\"]."
   }
   validation {
-    condition     = var.network_profile == null || var.network_profile.network_plugin == null || contains(["azure", "kubenet", "none"], var.network_profile.network_plugin)
+    condition     = var.network_profile == null || try(var.network_profile.network_plugin, null) == null || contains(["azure", "kubenet", "none"], coalesce(try(var.network_profile.network_plugin, null), ""))
     error_message = "network_profile.network_plugin must be one of: [\"azure\", \"kubenet\", \"none\"]."
   }
   validation {
-    condition     = var.network_profile == null || var.network_profile.network_plugin_mode == null || contains(["overlay"], var.network_profile.network_plugin_mode)
+    condition     = var.network_profile == null || try(var.network_profile.network_plugin_mode, null) == null || contains(["overlay"], coalesce(try(var.network_profile.network_plugin_mode, null), ""))
     error_message = "network_profile.network_plugin_mode must be one of: [\"overlay\"]."
   }
   validation {
-    condition     = var.network_profile == null || var.network_profile.network_policy == null || contains(["azure", "calico", "cilium", "none"], var.network_profile.network_policy)
+    condition     = var.network_profile == null || try(var.network_profile.network_policy, null) == null || contains(["azure", "calico", "cilium", "none"], coalesce(try(var.network_profile.network_policy, null), ""))
     error_message = "network_profile.network_policy must be one of: [\"azure\", \"calico\", \"cilium\", \"none\"]."
   }
   validation {
-    condition     = var.network_profile == null || var.network_profile.outbound_type == null || contains(["loadBalancer", "managedNATGateway", "none", "userAssignedNATGateway", "userDefinedRouting"], var.network_profile.outbound_type)
+    condition     = var.network_profile == null || try(var.network_profile.outbound_type, null) == null || contains(["loadBalancer", "managedNATGateway", "none", "userAssignedNATGateway", "userDefinedRouting"], coalesce(try(var.network_profile.outbound_type, null), ""))
     error_message = "network_profile.outbound_type must be one of: [\"loadBalancer\", \"managedNATGateway\", \"none\", \"userAssignedNATGateway\", \"userDefinedRouting\"]."
   }
   validation {
-    condition     = var.network_profile == null || var.network_profile.pod_cidr == null || can(regex("^([0-9]{1,3}\\.){3}[0-9]{1,3}(\\/([0-9]|[1-2][0-9]|3[0-2]))?$", var.network_profile.pod_cidr))
+    condition     = var.network_profile == null || try(var.network_profile.pod_cidr, null) == null || can(regex("^([0-9]{1,3}\\.){3}[0-9]{1,3}(\\/([0-9]|[1-2][0-9]|3[0-2]))?$", coalesce(try(var.network_profile.pod_cidr, null), "")))
     error_message = "network_profile.pod_cidr must match the pattern: ^([0-9]{1,3}\\.){3}[0-9]{1,3}(\\/([0-9]|[1-2][0-9]|3[0-2]))?$."
   }
   validation {
-    condition     = var.network_profile == null || var.network_profile.service_cidr == null || can(regex("^([0-9]{1,3}\\.){3}[0-9]{1,3}(\\/([0-9]|[1-2][0-9]|3[0-2]))?$", var.network_profile.service_cidr))
+    condition     = var.network_profile == null || try(var.network_profile.service_cidr, null) == null || can(regex("^([0-9]{1,3}\\.){3}[0-9]{1,3}(\\/([0-9]|[1-2][0-9]|3[0-2]))?$", coalesce(try(var.network_profile.service_cidr, null), "")))
     error_message = "network_profile.service_cidr must match the pattern: ^([0-9]{1,3}\\.){3}[0-9]{1,3}(\\/([0-9]|[1-2][0-9]|3[0-2]))?$."
   }
 }
@@ -954,11 +954,11 @@ The nodeProvisioningProfile of the resource.
 DESCRIPTION
 
   validation {
-    condition     = var.node_provisioning_profile == null || try(var.node_provisioning_profile.default_node_pools, null) == null || contains(["Auto", "None"], try(var.node_provisioning_profile.default_node_pools, ""))
+    condition     = var.node_provisioning_profile == null || try(var.node_provisioning_profile.default_node_pools, null) == null || contains(["Auto", "None"], coalesce(try(var.node_provisioning_profile.default_node_pools, null), ""))
     error_message = "node_provisioning_profile.default_node_pools must be one of: [\"Auto\", \"None\"]."
   }
   validation {
-    condition     = var.node_provisioning_profile == null || try(var.node_provisioning_profile.mode, null) == null || contains(["Auto", "Manual"], try(var.node_provisioning_profile.mode, ""))
+    condition     = var.node_provisioning_profile == null || try(var.node_provisioning_profile.mode, null) == null || contains(["Auto", "Manual"], coalesce(try(var.node_provisioning_profile.mode, null), ""))
     error_message = "node_provisioning_profile.mode must be one of: [\"Auto\", \"Manual\"]."
   }
 }
@@ -984,7 +984,7 @@ Node resource group lockdown profile for a managed cluster.
 DESCRIPTION
 
   validation {
-    condition     = var.node_resource_group_profile == null || try(var.node_resource_group_profile.restriction_level, null) == null || contains(["ReadOnly", "Unrestricted"], try(var.node_resource_group_profile.restriction_level, ""))
+    condition     = var.node_resource_group_profile == null || try(var.node_resource_group_profile.restriction_level, null) == null || contains(["ReadOnly", "Unrestricted"], coalesce(try(var.node_resource_group_profile.restriction_level, null), ""))
     error_message = "node_resource_group_profile.restriction_level must be one of: [\"ReadOnly\", \"Unrestricted\"]."
   }
 }
@@ -1103,7 +1103,7 @@ PublicNetworkAccess of the managedCluster. Allow or deny public network access f
 DESCRIPTION
 
   validation {
-    condition     = var.public_network_access == null || contains(["Disabled", "Enabled"], var.public_network_access)
+    condition     = var.public_network_access == null || contains(["Disabled", "Enabled"], coalesce(var.public_network_access, ""))
     error_message = "public_network_access must be one of: [\"Disabled\", \"Enabled\"]."
   }
 }
@@ -1183,7 +1183,7 @@ Security profile for the container service cluster.
 DESCRIPTION
 
   validation {
-    condition     = var.security_profile == null || var.security_profile.custom_ca_trust_certificates == null || length(var.security_profile.custom_ca_trust_certificates) <= 10
+    condition     = var.security_profile == null || try(length(var.security_profile.custom_ca_trust_certificates), 0) <= 10
     error_message = "security_profile.custom_ca_trust_certificates must have at most 10 item(s)."
   }
 }
@@ -1237,7 +1237,7 @@ Service mesh profile for a managed cluster.
 DESCRIPTION
 
   validation {
-    condition     = var.service_mesh_profile == null || contains(["Disabled", "Istio"], var.service_mesh_profile.mode)
+    condition     = var.service_mesh_profile == null || contains(["Disabled", "Istio"], coalesce(try(var.service_mesh_profile.mode, null), ""))
     error_message = "service_mesh_profile.mode must be one of: [\"Disabled\", \"Istio\"]."
   }
 }
@@ -1276,11 +1276,11 @@ See <https://learn.microsoft.com/azure/aks/intro-aks-automatic#aks-automatic-and
 DESCRIPTION
 
   validation {
-    condition     = var.sku == null || var.sku.name == null || contains(["Automatic", "Base"], var.sku.name)
+    condition     = var.sku == null || try(var.sku.name, null) == null || contains(["Automatic", "Base"], coalesce(try(var.sku.name, null), ""))
     error_message = "sku.name must be one of: [\"Automatic\", \"Base\"]."
   }
   validation {
-    condition     = var.sku == null || var.sku.tier == null || contains(["Free", "Premium", "Standard"], var.sku.tier)
+    condition     = var.sku == null || try(var.sku.tier, null) == null || contains(["Free", "Premium", "Standard"], coalesce(try(var.sku.tier, null), ""))
     error_message = "sku.tier must be one of: [\"Free\", \"Premium\", \"Standard\"]."
   }
 }
@@ -1324,7 +1324,7 @@ Different support tiers for AKS managed clusters
 DESCRIPTION
 
   validation {
-    condition     = var.support_plan == null || contains(["AKSLongTermSupport", "KubernetesOfficial"], var.support_plan)
+    condition     = var.support_plan == null || contains(["AKSLongTermSupport", "KubernetesOfficial"], coalesce(var.support_plan, ""))
     error_message = "support_plan must be one of: [\"AKSLongTermSupport\", \"KubernetesOfficial\"]."
   }
 }
@@ -1383,7 +1383,7 @@ Profile for Windows VMs in the managed cluster.
 DESCRIPTION
 
   validation {
-    condition     = var.windows_profile == null || var.windows_profile.license_type == null || contains(["None", "Windows_Server"], var.windows_profile.license_type)
+    condition     = var.windows_profile == null || try(var.windows_profile.license_type, null) == null || contains(["None", "Windows_Server"], coalesce(try(var.windows_profile.license_type, null), ""))
     error_message = "windows_profile.license_type must be one of: [\"None\", \"Windows_Server\"]."
   }
 }


### PR DESCRIPTION
## Summary

Fixes #189.

This PR hardens root module variable validations so optional nullable inputs do not attempt to read attributes from `null` values. It keeps the existing validation semantics while using `try(...)` and safe fallback values for nullable object attributes and enum checks.

Changes include:
- Guarding `node_provisioning_profile` and `node_resource_group_profile` validations.
- Extending the same null-safe pattern to the feedback list of optional inputs, including addon profiles, autoscaler/bootstrap/extended location/identity/network/security/service mesh/windows profile validations.
- Applying the same root-module pattern to related `auto_upgrade_profile` and `sku` validations.
- Adding unit coverage for null, valid, and invalid node profile cases.
- Including AVM-generated wrapper/docs updates required by pre-commit.

## Validation

- Live sandbox AKS deploy with Terraform `1.14.9` succeeded using explicit `null` values for the affected optional inputs.
- Live sandbox destroy succeeded; `az group exists --name rg-avm-aks-issue-189-live` returned `false`.
- `PORCH_NO_TUI=1 ./avm tf-test-unit` passed.
- `PORCH_NO_TUI=1 ./avm pre-commit` passed.
- `git diff --check` passed.
- VS Code diagnostics reported no errors in `variables.tf`.