### PR TITLE
Require Terraform 1.14 for nullable validation behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.11)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.14)
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.4)
 
@@ -2055,11 +2055,11 @@ Description: The FQDN of the master pool.
 
 ### <a name="output_identity_principal_id"></a> [identity\_principal\_id](#output\_identity\_principal\_id)
 
-Description: The principal id of the system assigned identity which is used by master components.
+Description: The principal id of the assigned identity which is used by master components.
 
 ### <a name="output_identity_tenant_id"></a> [identity\_tenant\_id](#output\_identity\_tenant\_id)
 
-Description: The tenant id of the system assigned identity which is used by master components.
+Description: The tenant id of the assigned identity which is used by master components.
 
 ### <a name="output_ingress_profile_web_app_routing_identity"></a> [ingress\_profile\_web\_app\_routing\_identity](#output\_ingress\_profile\_web\_app\_routing\_identity)
 

--- a/avm
+++ b/avm
@@ -173,6 +173,15 @@ if [ -f "avm.config.json" ]; then
   done
 fi
 
+# Forward AVM_BARE_* environment variables to the container with the prefix stripped
+while IFS='=' read -r bareKey bareValue; do
+  [ -z "$bareKey" ] && continue
+  strippedKey="${bareKey#AVM_BARE_}"
+  export "$strippedKey"="$bareValue"
+  LOCAL_ENVIRONMENT_VARIABLES="${LOCAL_ENVIRONMENT_VARIABLES}-e $strippedKey "
+  echo "Forwarding AVM bare variable to container as: $strippedKey"
+done < <(env | grep '^AVM_BARE_' || true)
+
 # Check if we are running in a container
 # If we are then just run make directly
 if [ -z "${AVM_IN_CONTAINER}" ]; then
@@ -199,7 +208,7 @@ if [ -z "${AVM_IN_CONTAINER}" ]; then
     -e TF_IN_AUTOMATION=1 \
     ${LOCAL_ENVIRONMENT_VARIABLES} \
     --env-file <(env | grep '^TF_VAR_') \
-    --env-file <(env | grep '^AVM_') \
+    --env-file <(env | grep '^AVM_' | grep -v '^AVM_BARE_') \
     "${CONTAINER_IMAGE}" \
     make \
     TUI="${TUI}" \

--- a/avm.ps1
+++ b/avm.ps1
@@ -150,9 +150,16 @@ if (-not $env:AVM_IN_CONTAINER) {
     $dockerArgs += @("-e", "$($_.Name)=$($_.Value)")
   }
 
-  # Add AVM_ environment variables
-  Get-ChildItem env: | Where-Object { $_.Name -like "AVM_*" } | ForEach-Object {
+  # Add AVM_ environment variables (excluding AVM_BARE_* which are forwarded with the prefix stripped)
+  Get-ChildItem env: | Where-Object { $_.Name -like "AVM_*" -and $_.Name -notlike "AVM_BARE_*" } | ForEach-Object {
     $dockerArgs += @("-e", "$($_.Name)=$($_.Value)")
+  }
+
+  # Forward AVM_BARE_* environment variables to the container with the prefix stripped
+  Get-ChildItem env: | Where-Object { $_.Name -like "AVM_BARE_*" } | ForEach-Object {
+    $strippedName = $_.Name -replace '^AVM_BARE_', ''
+    $dockerArgs += @("-e", "$strippedName=$($_.Value)")
+    Write-Host "Forwarding AVM bare variable to container as: $strippedName"
   }
 
   # Add local environment variables from avm.config.json

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.11"
+  required_version = "~> 1.14"
 
   required_providers {
     azapi = {


### PR DESCRIPTION
## Summary

Fixes #189.
Supersedes #191.

This PR raises the root module Terraform requirement to Terraform 1.14+ instead of changing the optional object validation expressions. Terraform 1.14.9 was validated against the original nullable validation shape and did not reproduce the reported `Attempt to get attribute from null value` failure.

Changes include:
- Update root `required_version` from `~> 1.11` to `>= 1.14.0, < 2.0.0`.
- Include AVM-generated documentation and wrapper updates from `./avm pre-commit`.
- Leave `variables.tf` validation logic unchanged from `main`.

## Validation

- Live AKS deploy from this branch with Terraform `1.14.9` succeeded using explicit `null` values for the affected optional inputs.
- Live AKS destroy succeeded; `az group exists --name rg-avm-aks-tf14-fix-live` returned `false`.
- `PORCH_NO_TUI=1 ./avm pre-commit` passed.
- `git diff --check` passed.
- VS Code diagnostics reported no errors in `terraform.tf`.

## Notes

A temporary validation root was pinned to `>= 1.14.0, < 1.15.0` to ensure the live deployment used Terraform 1.14.9 specifically.