### PR TITLE
Fix Azure Policy addon config passthrough

### DIFF
--- a/locals.addon_profiles.tf
+++ b/locals.addon_profiles.tf
@@ -15,7 +15,7 @@ locals {
     var.addon_profile_azure_policy != null && !local.is_automatic ? {
       azurepolicy = {
         enabled = var.addon_profile_azure_policy.enabled
-        config  = null
+        config  = var.addon_profile_azure_policy.config
       }
     } : null,
     var.addon_profile_ingress_application_gateway != null ? {

--- a/tests/unit/addon_profiles.tftest.hcl
+++ b/tests/unit/addon_profiles.tftest.hcl
@@ -1,0 +1,28 @@
+mock_provider "azapi" {}
+mock_provider "azurerm" {}
+mock_provider "modtm" {}
+mock_provider "random" {}
+
+variables {
+  location  = "eastus"
+  name      = "test-aks"
+  parent_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test"
+}
+
+run "azure_policy_config_is_passed_through" {
+  command = plan
+
+  variables {
+    addon_profile_azure_policy = {
+      enabled = true
+      config = {
+        version = "v2"
+      }
+    }
+  }
+
+  assert {
+    condition     = try(azapi_resource.this.body.properties.addonProfiles.azurepolicy.config.version, null) == "v2"
+    error_message = "Azure Policy addon config should be passed through to the managed cluster addon profile."
+  }
+}


### PR DESCRIPTION
## Summary
- Pass `addon_profile_azure_policy.config` through to the AKS `azurepolicy` addon profile instead of dropping it as `null`.
- Add a unit regression test that validates the generated AzAPI body includes `config.version = "v2"`.

Closes #193

## Validation
- Live sandbox repro before fix: deployed AKS returned `addonProfiles.azurepolicy.config = null`.
- Live sandbox update after fix: AKS returned `addonProfiles.azurepolicy.config.version = "v2"`.
- Destroyed the temporary repro resources and verified the resource group no longer exists.
- `PORCH_NO_TUI=1 ./avm tf-test-unit`
- `PORCH_NO_TUI=1 ./avm pre-commit`