### PR TITLE
Fix AKS control plane version upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.14)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.4)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.46.0, < 5.0.0)
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The following resources are used by this module:
 - [azapi_resource_action.this_admin_kubeconfig](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource_action) (resource)
 - [azapi_resource_action.this_user_kubeconfig](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource_action) (resource)
 - [azapi_update_resource.default_agent_pool](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/update_resource) (resource)
+- [azapi_update_resource.kubernetes_version](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/update_resource) (resource)
 - [azurerm_management_lock.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_lock) (resource)
 - [azurerm_monitor_diagnostic_setting.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) (resource)
 - [azurerm_private_endpoint.this_managed_dns_zone_groups](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) (resource)

--- a/main.tf
+++ b/main.tf
@@ -54,8 +54,28 @@ resource "azapi_resource" "this" {
   lifecycle {
     ignore_changes = [
       body.properties.agentPoolProfiles,
+      body.properties.kubernetesVersion,
     ]
   }
+}
+
+resource "azapi_update_resource" "kubernetes_version" {
+  count = var.kubernetes_version == null ? 0 : 1
+
+  name      = var.name
+  parent_id = var.parent_id
+  type      = azapi_resource.this.type
+  body = {
+    properties = {
+      kubernetesVersion = var.kubernetes_version
+    }
+  }
+  locks = [
+    azapi_resource.this.id,
+  ]
+  read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  response_export_values = []
+  update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 }
 
 resource "random_string" "dns_prefix" {

--- a/main.tf
+++ b/main.tf
@@ -52,9 +52,7 @@ resource "azapi_resource" "this" {
   }
 
   lifecycle {
-    # TODO: When https://github.com/Azure/terraform-provider-azapi/pull/1033 is merged, we can remove this.
     ignore_changes = [
-      body.properties.kubernetesVersion,
       body.properties.agentPoolProfiles,
     ]
   }

--- a/modules/agentpool/README.md
+++ b/modules/agentpool/README.md
@@ -9,7 +9,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.11)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.7)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
 
 ## Resources
 

--- a/modules/agentpool/terraform.tf
+++ b/modules/agentpool/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "azure/azapi"
-      version = "~> 2.7"
+      version = "~> 2.9"
     }
   }
 }

--- a/modules/alerting/README.md
+++ b/modules/alerting/README.md
@@ -11,7 +11,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.6.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.4)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
 
 ## Resources
 

--- a/modules/alerting/terraform.tf
+++ b/modules/alerting/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.4"
+      version = "~> 2.9"
     }
   }
 }

--- a/modules/maintenanceconfiguration/README.md
+++ b/modules/maintenanceconfiguration/README.md
@@ -9,7 +9,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.11)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.7)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
 
 ## Resources
 

--- a/modules/maintenanceconfiguration/terraform.tf
+++ b/modules/maintenanceconfiguration/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "azure/azapi"
-      version = "~> 2.7"
+      version = "~> 2.9"
     }
   }
 }

--- a/modules/monitoring/README.md
+++ b/modules/monitoring/README.md
@@ -11,7 +11,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.6.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.4)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
 
 ## Resources
 

--- a/modules/monitoring/terraform.tf
+++ b/modules/monitoring/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.4"
+      version = "~> 2.9"
     }
   }
 }

--- a/modules/namespace/README.md
+++ b/modules/namespace/README.md
@@ -9,7 +9,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.11)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.7)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
 
 ## Resources
 

--- a/modules/namespace/terraform.tf
+++ b/modules/namespace/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "azure/azapi"
-      version = "~> 2.7"
+      version = "~> 2.9"
     }
   }
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.4"
+      version = "~> 2.9"
     }
     azurerm = {
       source  = "hashicorp/azurerm"


### PR DESCRIPTION
## Summary
- Remove the stale lifecycle ignore for `body.properties.kubernetesVersion` so AKS control plane version changes are planned and applied.
- Keep `body.properties.agentPoolProfiles` ignored for the existing default agent pool update pattern.
- Require AzAPI provider `~> 2.9` across the root module and submodules so the upstream provider fix is present.
- Regenerate module READMEs for the updated provider requirement.

Closes #188

## Validation
- Reproduced on Terraform `1.14.9` with AzAPI `2.9.0`: changing `kubernetes_version` from `1.33.11` to `1.34.7` planned `No changes` before the fix.
- After the fix, the same repro planned an in-place update: `kubernetesVersion = "1.33.11" -> "1.34.7"`.
- Applied the fixed plan successfully; Azure reported `currentKubernetesVersion = "1.34.7"` and `provisioningState = "Succeeded"`.
- Destroyed the temporary repro resources and verified the resource group no longer exists.
- `PORCH_NO_TUI=1 ./avm tf-test-unit`
- `PORCH_NO_TUI=1 ./avm pre-commit`