### PR TITLE
Fix Automatic cluster create payload

### DIFF
--- a/locals.agent_pool_profiles.tf
+++ b/locals.agent_pool_profiles.tf
@@ -10,18 +10,18 @@ locals {
   agent_pool_profiles = [
     merge(
       {
-        for k, v in module.default_agent_pool_data.body_properties : k => v if can(regex(local.agent_pool_profiles_regex, k)) && !contains(local.agent_pool_profiles_excluded_properties, k) && k != "securityProfile" && v != null
+        for k, v in local.agent_pool_profiles_create_body_properties : k => v if can(regex(local.agent_pool_profiles_regex, k)) && !contains(local.agent_pool_profiles_excluded_properties, k) && k != "securityProfile" && v != null
       },
       {
         for k, v in {
           kubeletConfig = {
-            for profile_key, profile_value in coalesce(try(module.default_agent_pool_data.body_properties.kubeletConfig, null), {}) : profile_key => profile_value if profile_key != "seccompDefault" && profile_value != null
+            for profile_key, profile_value in coalesce(try(local.agent_pool_profiles_create_body_properties.kubeletConfig, null), {}) : profile_key => profile_value if profile_key != "seccompDefault" && profile_value != null
           }
           localDNSProfile = {
-            for profile_key, profile_value in coalesce(try(module.default_agent_pool_data.body_properties.localDNSProfile, null), {}) : profile_key => profile_value if profile_key != "state" && profile_value != null
+            for profile_key, profile_value in coalesce(try(local.agent_pool_profiles_create_body_properties.localDNSProfile, null), {}) : profile_key => profile_value if profile_key != "state" && profile_value != null
           }
           upgradeSettings = {
-            for profile_key, profile_value in coalesce(try(module.default_agent_pool_data.body_properties.upgradeSettings, null), {}) : profile_key => profile_value if profile_key != "maxBlockedNodes" && profile_value != null
+            for profile_key, profile_value in coalesce(try(local.agent_pool_profiles_create_body_properties.upgradeSettings, null), {}) : profile_key => profile_value if profile_key != "maxBlockedNodes" && profile_value != null
           }
         } : k => v if try(length(v), 0) > 0
       },
@@ -30,6 +30,12 @@ locals {
       }
     )
   ]
+  agent_pool_profiles_create_body_properties = merge(
+    module.default_agent_pool_data.body_properties,
+    {
+      count = local.is_automatic ? var.default_agent_pool.count_of : module.default_agent_pool_data.body_properties.count
+    }
+  )
   agent_pool_profiles_excluded_properties = [
     "artifactStreamingProfile",
     "enableOSDiskFullCaching",

--- a/locals.resource_body.tf
+++ b/locals.resource_body.tf
@@ -260,18 +260,24 @@ locals {
     for k, v in local.resource_body_full.properties : k => v if can(regex(local.resource_body_properties_regex, k)) && v != null
   }
   resource_body_properties_automatic = [
+    "aadProfile",
     "addonProfiles",
     "agentPoolProfiles",
     "apiServerAccessProfile",
+    "autoUpgradeProfile",
     "azureMonitorProfile",
     "diskEncryptionSetID",
     "ingressProfile",
     "kubernetesVersion",
     "metricsProfile",
     "networkProfile",
+    "nodeProvisioningProfile",
     "nodeResourceGroup",
+    "oidcIssuerProfile",
+    "securityProfile",
     "serviceMeshProfile",
     "storageProfile",
+    "workloadAutoScalerProfile",
   ]
   resource_body_properties_regex           = local.is_automatic ? local.resource_body_properties_regex_automatic : local.resource_body_properties_regex_standard
   resource_body_properties_regex_automatic = "^(${join("|", local.resource_body_properties_automatic)})$"

--- a/tests/unit/automatic_payload.tftest.hcl
+++ b/tests/unit/automatic_payload.tftest.hcl
@@ -1,0 +1,102 @@
+mock_provider "azapi" {}
+mock_provider "azurerm" {}
+mock_provider "modtm" {}
+mock_provider "random" {}
+
+variables {
+  location  = "eastus"
+  name      = "test-aks"
+  parent_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test"
+  sku = {
+    name = "Automatic"
+    tier = "Standard"
+  }
+}
+
+run "automatic_autoscaling_default_pool_keeps_create_count" {
+  command = plan
+
+  variables {
+    default_agent_pool = {
+      count_of            = 1
+      enable_auto_scaling = true
+      min_count           = 1
+      max_count           = 3
+    }
+  }
+
+  assert {
+    condition     = azapi_resource.this.body.properties.agentPoolProfiles[0].count == 1
+    error_message = "Automatic cluster create payload should include the default agent pool count even when autoscaling is configured."
+  }
+}
+
+run "automatic_cluster_supported_profiles_are_passed_through" {
+  command = plan
+
+  variables {
+    aad_profile = {
+      admin_group_object_ids = ["00000000-0000-0000-0000-000000000001"]
+      enable_azure_rbac      = true
+      managed                = true
+    }
+    auto_upgrade_profile = {
+      node_os_upgrade_channel = "NodeImage"
+      upgrade_channel         = "stable"
+    }
+    node_provisioning_profile = {
+      default_node_pools = "Auto"
+      mode               = "Auto"
+    }
+    oidc_issuer_profile = {
+      enabled = true
+    }
+    security_profile = {
+      image_cleaner = {
+        enabled        = true
+        interval_hours = 48
+      }
+      workload_identity = {
+        enabled = true
+      }
+    }
+    workload_auto_scaler_profile = {
+      keda = {
+        enabled = true
+      }
+      vertical_pod_autoscaler = {
+        enabled = true
+      }
+    }
+  }
+
+  assert {
+    condition     = azapi_resource.this.body.properties.aadProfile.adminGroupObjectIDs[0] == "00000000-0000-0000-0000-000000000001"
+    error_message = "Automatic cluster payload should pass through aadProfile admin groups."
+  }
+
+  assert {
+    condition     = azapi_resource.this.body.properties.autoUpgradeProfile.upgradeChannel == "stable"
+    error_message = "Automatic cluster payload should pass through autoUpgradeProfile."
+  }
+
+  assert {
+    condition     = azapi_resource.this.body.properties.nodeProvisioningProfile.mode == "Auto"
+    error_message = "Automatic cluster payload should pass through nodeProvisioningProfile."
+  }
+
+  assert {
+    condition     = azapi_resource.this.body.properties.oidcIssuerProfile.enabled == true
+    error_message = "Automatic cluster payload should pass through oidcIssuerProfile."
+  }
+
+  assert {
+    condition     = azapi_resource.this.body.properties.securityProfile.workloadIdentity.enabled == true
+    error_message = "Automatic cluster payload should pass through securityProfile."
+  }
+
+  assert {
+    condition     = azapi_resource.this.body.properties.workloadAutoScalerProfile.keda.enabled == true
+    error_message = "Automatic cluster payload should pass through workloadAutoScalerProfile."
+  }
+}


### PR DESCRIPTION
Fixes #184

## Summary
- Keep the default agent pool `count` in the parent managed cluster create payload for Automatic clusters, even when autoscaling settings are modeled for the agent pool helper.
- Expand the Automatic SKU property allowlist so supported profiles such as AAD, auto-upgrade, OIDC issuer, security, workload autoscaler, and node provisioning pass through instead of being silently stripped.
- Add unit coverage for the Automatic autoscaling create payload and supported profile passthrough behavior.

## Validation
- `terraform fmt -recursive`
- `PORCH_NO_TUI=1 ./avm tf-test-unit`
- `PORCH_NO_TUI=1 ./avm pre-commit`
- Live sandbox deploy in subscription `d2c79ad4-f497-44b6-a2d7-e7477a6068cb`: `aks184cleanp4fojh` in `rg-aks184clean-p4fojh` reached `Succeeded` with Automatic SKU, `agentPoolProfiles[0].count = 1`, and the supported profile fields present.
- Live sandbox cleanup completed; `az group exists -n rg-aks184clean-p4fojh` returned `false`.