### PR TITLE
Hosted system profile configuration

### DIFF
--- a/examples/automatic-private/_header.md
+++ b/examples/automatic-private/_header.md
@@ -1,6 +1,6 @@
 # Private AKS Automatic example
 
-This deploys a private AKS Automatic cluster in a custom virtual network, including API server and node subnets, private DNS zone, user-assigned identity with role assignments, Log Analytics + Azure Monitor workspace, and default monitoring/alerts.
+This deploys a private AKS Automatic cluster in a customer-owned (BYO) virtual network. The example provisions API server, user-node and system-node subnets, a private DNS zone, a user-assigned identity with role assignments, a Log Analytics + Azure Monitor workspace, and default monitoring/alerts. The `hosted_system_profile` input wires the user and system subnets into the hosted system components required when bringing your own virtual network to AKS Automatic.
 
 To connect to the private cluster after deployment, use one of the supported methods described in the [Azure documentation on connecting to a private cluster](https://learn.microsoft.com/azure/aks/private-cluster-connect?pivots=azure-cloud-shell).
 

--- a/examples/automatic-private/main.tf
+++ b/examples/automatic-private/main.tf
@@ -93,6 +93,13 @@ resource "azurerm_subnet" "cluster" {
   virtual_network_name = azurerm_virtual_network.this.name
 }
 
+resource "azurerm_subnet" "system" {
+  address_prefixes     = ["172.19.2.0/24"]
+  name                 = "systemSubnet"
+  resource_group_name  = azurerm_resource_group.this.name
+  virtual_network_name = azurerm_virtual_network.this.name
+}
+
 resource "azurerm_user_assigned_identity" "this" {
   location            = azurerm_resource_group.this.location
   name                = module.naming.user_assigned_identity.name_unique
@@ -153,6 +160,11 @@ module "automatic" {
   }
   default_agent_pool = {
     vnet_subnet_id = azurerm_subnet.cluster.id
+  }
+  hosted_system_profile = {
+    enabled               = true
+    node_subnet_id        = azurerm_subnet.cluster.id
+    system_node_subnet_id = azurerm_subnet.system.id
   }
   ingress_profile = {
     web_app_routing = {

--- a/locals.resource_body.tf
+++ b/locals.resource_body.tf
@@ -83,6 +83,11 @@ locals {
       dnsPrefix            = var.fqdn_subdomain != null ? null : coalesce(var.dns_prefix, random_string.dns_prefix.result)
       enableRBAC           = var.enable_rbac
       fqdnSubdomain        = var.fqdn_subdomain
+      hostedSystemProfile = var.hosted_system_profile == null ? null : {
+        enabled            = var.hosted_system_profile.enabled
+        nodeSubnetID       = var.hosted_system_profile.node_subnet_id
+        systemNodeSubnetID = var.hosted_system_profile.system_node_subnet_id
+      }
       httpProxyConfig = var.http_proxy_config == null ? null : {
         httpProxy  = var.http_proxy_config.http_proxy
         httpsProxy = var.http_proxy_config.https_proxy
@@ -267,6 +272,7 @@ locals {
     "autoUpgradeProfile",
     "azureMonitorProfile",
     "diskEncryptionSetID",
+    "hostedSystemProfile",
     "ingressProfile",
     "kubernetesVersion",
     "metricsProfile",

--- a/tests/unit/hosted_system_profile.tftest.hcl
+++ b/tests/unit/hosted_system_profile.tftest.hcl
@@ -1,0 +1,84 @@
+mock_provider "azapi" {}
+mock_provider "azurerm" {}
+mock_provider "modtm" {}
+mock_provider "random" {}
+
+variables {
+  location  = "eastus"
+  name      = "test-aks"
+  parent_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test"
+  sku = {
+    name = "Automatic"
+    tier = "Standard"
+  }
+}
+
+run "hosted_system_profile_omitted_when_null" {
+  command = plan
+
+  assert {
+    condition     = !can(azapi_resource.this.body.properties.hostedSystemProfile)
+    error_message = "hostedSystemProfile must be omitted from the payload when hosted_system_profile is null."
+  }
+}
+
+run "hosted_system_profile_serializes_subnet_ids" {
+  command = plan
+
+  variables {
+    hosted_system_profile = {
+      enabled               = true
+      node_subnet_id        = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet/subnets/nodes"
+      system_node_subnet_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet/subnets/system"
+    }
+  }
+
+  assert {
+    condition     = azapi_resource.this.body.properties.hostedSystemProfile.enabled == true
+    error_message = "hostedSystemProfile.enabled should be serialized."
+  }
+
+  assert {
+    condition     = azapi_resource.this.body.properties.hostedSystemProfile.nodeSubnetID == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet/subnets/nodes"
+    error_message = "hostedSystemProfile.nodeSubnetID should match the provided node_subnet_id."
+  }
+
+  assert {
+    condition     = azapi_resource.this.body.properties.hostedSystemProfile.systemNodeSubnetID == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet/subnets/system"
+    error_message = "hostedSystemProfile.systemNodeSubnetID should match the provided system_node_subnet_id."
+  }
+}
+
+run "hosted_system_profile_requires_subnet_ids_when_enabled" {
+  command = plan
+
+  variables {
+    hosted_system_profile = {
+      enabled = true
+    }
+  }
+
+  expect_failures = [
+    var.hosted_system_profile,
+  ]
+}
+
+run "hosted_system_profile_rejects_non_automatic_sku" {
+  command = plan
+
+  variables {
+    sku = {
+      name = "Base"
+      tier = "Standard"
+    }
+    hosted_system_profile = {
+      enabled               = true
+      node_subnet_id        = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet/subnets/nodes"
+      system_node_subnet_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet/subnets/system"
+    }
+  }
+
+  expect_failures = [
+    var.hosted_system_profile,
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -668,6 +668,35 @@ The FQDN subdomain of the private cluster with custom private dns zone. This can
 DESCRIPTION
 }
 
+variable "hosted_system_profile" {
+  type = object({
+    enabled               = optional(bool)
+    node_subnet_id        = optional(string)
+    system_node_subnet_id = optional(string)
+  })
+  default     = null
+  description = <<DESCRIPTION
+Hosted system profile for the managed cluster. Used by AKS Automatic clusters provisioned into a customer-owned (BYO) virtual network to declare the subnets that the hosted system components use.
+
+- `enabled` - Whether to enable the hosted system profile.
+- `node_subnet_id` - Resource ID of the subnet to be used for user/workload nodes. Required when `enabled` is true.
+- `system_node_subnet_id` - Resource ID of the subnet to be used for system node pools. Required when `enabled` is true.
+
+This property is only honored by AKS Automatic clusters (`sku.name == "Automatic"`); it is ignored for standard clusters.
+DESCRIPTION
+
+  validation {
+    condition = var.hosted_system_profile == null || var.hosted_system_profile.enabled != true || (
+      var.hosted_system_profile.node_subnet_id != null && var.hosted_system_profile.system_node_subnet_id != null
+    )
+    error_message = "When hosted_system_profile.enabled is true, both hosted_system_profile.node_subnet_id and hosted_system_profile.system_node_subnet_id must be set."
+  }
+  validation {
+    condition     = var.hosted_system_profile == null || (var.sku != null && var.sku.name == "Automatic")
+    error_message = "hosted_system_profile is only supported for AKS Automatic clusters (sku.name must be \"Automatic\")."
+  }
+}
+
 variable "http_proxy_config" {
   type = object({
     http_proxy  = optional(string)


### PR DESCRIPTION
## Description

Add support for [ManagedClusterHostedSystemProfile](https://learn.microsoft.com/en-us/rest/api/aks/managed-clusters/create-or-update?view=rest-aks-2026-04-01&tabs=HTTP#managedclusterhostedsystemprofile)

This property is required in the REST API request for provisioning an AKS Automatic cluster with BYO VNet. Without this configuration present the API responds with error:

```
--------------------------------------------------------------------------------
RESPONSE 400: 400 Bad Request
ERROR CODE: EmptySubnetError
--------------------------------------------------------------------------------
{
  "code": "EmptySubnetError",
  "details": null,
  "message": "The input subnet is an empty string.",
  "subcode": ""
}
--------------------------------------------------------------------------------
```

Closes #199 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
