### PR TITLE
fix: keep agent pool upgrade_settings numeric attributes as int32

### DIFF
--- a/locals.agent_pool_profiles.tf
+++ b/locals.agent_pool_profiles.tf
@@ -13,15 +13,21 @@ locals {
         for k, v in local.agent_pool_profiles_create_body_properties : k => v if can(regex(local.agent_pool_profiles_regex, k)) && !contains(local.agent_pool_profiles_excluded_properties, k) && k != "securityProfile" && v != null
       },
       {
+        # Strip null-valued attributes from each nested object. Do NOT wrap the source with
+        # `coalesce(obj, {})`: coalescing a populated object with the empty object `{}`
+        # unifies them to `map(string)`, silently coercing numeric attributes (e.g.
+        # upgradeSettings.drainTimeoutInMinutes / nodeSoakDurationInMinutes) into strings,
+        # which the AKS API rejects ("drainTimeoutInMinutes accept type int32, not type
+        # string"). A null-guarding ternary preserves each attribute's original type.
         for k, v in {
-          kubeletConfig = {
-            for profile_key, profile_value in coalesce(try(local.agent_pool_profiles_create_body_properties.kubeletConfig, null), {}) : profile_key => profile_value if profile_key != "seccompDefault" && profile_value != null
+          kubeletConfig = try(local.agent_pool_profiles_create_body_properties.kubeletConfig, null) == null ? null : {
+            for profile_key, profile_value in local.agent_pool_profiles_create_body_properties.kubeletConfig : profile_key => profile_value if profile_key != "seccompDefault" && profile_value != null
           }
-          localDNSProfile = {
-            for profile_key, profile_value in coalesce(try(local.agent_pool_profiles_create_body_properties.localDNSProfile, null), {}) : profile_key => profile_value if profile_key != "state" && profile_value != null
+          localDNSProfile = try(local.agent_pool_profiles_create_body_properties.localDNSProfile, null) == null ? null : {
+            for profile_key, profile_value in local.agent_pool_profiles_create_body_properties.localDNSProfile : profile_key => profile_value if profile_key != "state" && profile_value != null
           }
-          upgradeSettings = {
-            for profile_key, profile_value in coalesce(try(local.agent_pool_profiles_create_body_properties.upgradeSettings, null), {}) : profile_key => profile_value if profile_key != "maxBlockedNodes" && profile_value != null
+          upgradeSettings = try(local.agent_pool_profiles_create_body_properties.upgradeSettings, null) == null ? null : {
+            for profile_key, profile_value in local.agent_pool_profiles_create_body_properties.upgradeSettings : profile_key => profile_value if profile_key != "maxBlockedNodes" && profile_value != null
           }
         } : k => v if try(length(v), 0) > 0
       },

--- a/main.default_agent_pool.tf
+++ b/main.default_agent_pool.tf
@@ -73,24 +73,31 @@ resource "azapi_update_resource" "default_agent_pool" {
         for k, v in module.default_agent_pool_data.body_properties : k => v if v != null && k != "nodeInitializationTaints" && !contains(["gpuProfile", "kubeletConfig", "localDNSProfile", "securityProfile", "upgradeSettings", "upgradeSettingsBlueGreen"], k)
       },
       {
+        # Strip null-valued attributes from each nested object so they are not sent in the
+        # PUT body. Do NOT wrap the source with `coalesce(obj, {})`: coalescing a populated
+        # object with the empty object `{}` unifies them to `map(string)`, silently coercing
+        # numeric attributes (e.g. upgradeSettings.drainTimeoutInMinutes /
+        # nodeSoakDurationInMinutes) into strings. The AKS API then rejects the request with
+        # "drainTimeoutInMinutes accept type int32, not type string". Guarding the null case
+        # with a ternary preserves each attribute's original type.
         for k, v in {
-          gpuProfile = {
-            for profile_key, profile_value in coalesce(try(module.default_agent_pool_data.body_properties.gpuProfile, null), {}) : profile_key => profile_value if profile_value != null
+          gpuProfile = try(module.default_agent_pool_data.body_properties.gpuProfile, null) == null ? null : {
+            for profile_key, profile_value in module.default_agent_pool_data.body_properties.gpuProfile : profile_key => profile_value if profile_value != null
           }
-          kubeletConfig = {
-            for profile_key, profile_value in coalesce(try(module.default_agent_pool_data.body_properties.kubeletConfig, null), {}) : profile_key => profile_value if profile_value != null
+          kubeletConfig = try(module.default_agent_pool_data.body_properties.kubeletConfig, null) == null ? null : {
+            for profile_key, profile_value in module.default_agent_pool_data.body_properties.kubeletConfig : profile_key => profile_value if profile_value != null
           }
-          localDNSProfile = {
-            for profile_key, profile_value in coalesce(try(module.default_agent_pool_data.body_properties.localDNSProfile, null), {}) : profile_key => profile_value if profile_value != null
+          localDNSProfile = try(module.default_agent_pool_data.body_properties.localDNSProfile, null) == null ? null : {
+            for profile_key, profile_value in module.default_agent_pool_data.body_properties.localDNSProfile : profile_key => profile_value if profile_value != null
           }
-          securityProfile = {
-            for profile_key, profile_value in coalesce(try(module.default_agent_pool_data.body_properties.securityProfile, null), {}) : profile_key => profile_value if profile_value != null
+          securityProfile = try(module.default_agent_pool_data.body_properties.securityProfile, null) == null ? null : {
+            for profile_key, profile_value in module.default_agent_pool_data.body_properties.securityProfile : profile_key => profile_value if profile_value != null
           }
-          upgradeSettings = {
-            for profile_key, profile_value in coalesce(try(module.default_agent_pool_data.body_properties.upgradeSettings, null), {}) : profile_key => profile_value if profile_value != null
+          upgradeSettings = try(module.default_agent_pool_data.body_properties.upgradeSettings, null) == null ? null : {
+            for profile_key, profile_value in module.default_agent_pool_data.body_properties.upgradeSettings : profile_key => profile_value if profile_value != null
           }
-          upgradeSettingsBlueGreen = {
-            for profile_key, profile_value in coalesce(try(module.default_agent_pool_data.body_properties.upgradeSettingsBlueGreen, null), {}) : profile_key => profile_value if profile_value != null
+          upgradeSettingsBlueGreen = try(module.default_agent_pool_data.body_properties.upgradeSettingsBlueGreen, null) == null ? null : {
+            for profile_key, profile_value in module.default_agent_pool_data.body_properties.upgradeSettingsBlueGreen : profile_key => profile_value if profile_value != null
           }
         } : k => v if try(length(v), 0) > 0
       }

--- a/tests/unit/agent_pool_upgrade_settings_types.tftest.hcl
+++ b/tests/unit/agent_pool_upgrade_settings_types.tftest.hcl
@@ -1,0 +1,63 @@
+mock_provider "azapi" {}
+mock_provider "azurerm" {}
+mock_provider "modtm" {}
+mock_provider "random" {}
+
+variables {
+  location  = "eastus"
+  name      = "test-aks"
+  parent_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test"
+  sku = {
+    name = "Base"
+    tier = "Standard"
+  }
+}
+
+# Regression test for the agent pool update payload.
+#
+# The default agent pool is updated via `azapi_update_resource.default_agent_pool`, whose
+# body is assembled by stripping null attributes from each nested object. A previous
+# implementation wrapped those objects with `coalesce(obj, {})`, which unified the populated
+# object with the empty object `{}` to `map(string)` and silently coerced numeric attributes
+# (drainTimeoutInMinutes / nodeSoakDurationInMinutes) into strings. The AKS API then rejected
+# the request with "drainTimeoutInMinutes accept type int32, not type string".
+#
+# These assertions fail if the numeric upgrade settings are serialized as strings.
+run "default_agent_pool_upgrade_settings_keep_numeric_types" {
+  command = plan
+
+  variables {
+    default_agent_pool = {
+      name    = "systempool"
+      vm_size = "Standard_D4ads_v6"
+      upgrade_settings = {
+        drain_timeout_in_minutes      = 30
+        max_surge                     = "35%"
+        node_soak_duration_in_minutes = 15
+      }
+    }
+  }
+
+  # Number equality is type-aware in HCL ("30" == 30 is false), so these fail if coerced.
+  assert {
+    condition     = azapi_update_resource.default_agent_pool.body.properties.upgradeSettings.drainTimeoutInMinutes == 30
+    error_message = "drainTimeoutInMinutes must stay an int32 in the agent pool update payload, not be coerced to a string."
+  }
+
+  assert {
+    condition     = azapi_update_resource.default_agent_pool.body.properties.upgradeSettings.nodeSoakDurationInMinutes == 15
+    error_message = "nodeSoakDurationInMinutes must stay an int32 in the agent pool update payload, not be coerced to a string."
+  }
+
+  # Belt and suspenders: a number serializes as `30`, a string as `"30"`.
+  assert {
+    condition     = strcontains(jsonencode(azapi_update_resource.default_agent_pool.body.properties.upgradeSettings), "\"drainTimeoutInMinutes\":30")
+    error_message = "drainTimeoutInMinutes must serialize as a JSON number, not a quoted string."
+  }
+
+  # String-typed sibling attribute must remain a string.
+  assert {
+    condition     = azapi_update_resource.default_agent_pool.body.properties.upgradeSettings.maxSurge == "35%"
+    error_message = "maxSurge must stay a string in the agent pool update payload."
+  }
+}


### PR DESCRIPTION
## Summary

Since `v0.6.0`, applying an agent pool **update** fails when `upgrade_settings` is set:

```
RESPONSE 400: 400 Bad Request
ERROR CODE: UnmarshalError
UpgradeSettings.properties.upgradeSettings.drainTimeoutInMinutes accept type int32, not type string.
```

`drainTimeoutInMinutes` (and `nodeSoakDurationInMinutes`) are declared `optional(number)`, yet the payload sends them as JSON strings (`"30"`), which the AKS API rejects.

## Root cause

`main.default_agent_pool.tf` (the `azapi_update_resource.default_agent_pool` body) and `locals.agent_pool_profiles.tf` (the cluster-create profile) strip null attributes from each nested object, wrapping the source with `coalesce(obj, {})` to handle the null case:

```hcl
upgradeSettings = {
  for k, v in coalesce(try(...upgradeSettings, null), {}) : k => v if v != null
}
```

`coalesce` unifies the types of its arguments. Coalescing a populated object with the **empty object literal `{}`** unifies them to `map(string)`, which silently coerces every numeric attribute to a string. The inner `for` comprehension itself is fine — the coercion comes entirely from `coalesce(obj, {})`.

Minimal `terraform console` repro:

```hcl
> jsonencode({ for k, v in coalesce(try({ drainTimeoutInMinutes = 30, maxSurge = "35%" }, null), {}) : k => v if v != null })
"{\"drainTimeoutInMinutes\":\"30\",\"maxSurge\":\"35%\"}"   # 30 became "30"
```

This affects `upgradeSettings`, `kubeletConfig`, `localDNSProfile`, `securityProfile`, etc. — any nested object mixing numeric and string attributes.

## Fix

Replace `coalesce(obj, {})` with a null-guarding ternary that iterates the source object directly when it is non-null. This preserves each attribute's original type:

```hcl
upgradeSettings = try(...upgradeSettings, null) == null ? null : {
  for k, v in ...upgradeSettings : k => v if v != null
}
```

The outer `... if try(length(v), 0) > 0` filter already drops `null`/empty sub-objects, so behaviour is otherwise unchanged.

## Tests

- Adds `tests/unit/agent_pool_upgrade_settings_types.tftest.hcl`, which plans the default agent pool with `upgrade_settings` and asserts the numeric attributes stay int32 (both via type-aware `== 30` equality and a `jsonencode` check). It **fails** on the previous `coalesce`-based code and passes with this fix.
- Full `tests/unit` suite: 11 passed, 0 failed. `terraform fmt`/`validate` clean.