### PR TITLE
Expose monitoring data collection endpoint outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2128,6 +2128,14 @@ Description: Base64 cluster CA certificate from user kubeconfig.
 
 Description: The version of Kubernetes the Managed Cluster is running. If kubernetesVersion was a fully specified version <major.minor.patch>, this field will be exactly equal to it. If kubernetesVersion was <major.minor>, this field will contain the full <major.minor.patch> version being used.
 
+### <a name="output_data_collection_endpoint_id"></a> [data\_collection\_endpoint\_id](#output\_data\_collection\_endpoint\_id)
+
+Description: The resource ID of the data collection endpoint created by the monitoring submodule.
+
+### <a name="output_data_collection_endpoint_name"></a> [data\_collection\_endpoint\_name](#output\_data\_collection\_endpoint\_name)
+
+Description: The name of the data collection endpoint created by the monitoring submodule.
+
 ### <a name="output_fqdn"></a> [fqdn](#output\_fqdn)
 
 Description: The FQDN of the master pool.

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,6 +13,16 @@ output "current_kubernetes_version" {
   value       = try(azapi_resource.this.output.properties.currentKubernetesVersion, null)
 }
 
+output "data_collection_endpoint_id" {
+  description = "The resource ID of the data collection endpoint created by the monitoring submodule."
+  value       = try(module.monitoring[0].data_collection_endpoint_id, null)
+}
+
+output "data_collection_endpoint_name" {
+  description = "The name of the data collection endpoint created by the monitoring submodule."
+  value       = try(module.monitoring[0].data_collection_endpoint_name, null)
+}
+
 output "fqdn" {
   description = "The FQDN of the master pool."
   value       = try(azapi_resource.this.output.properties.fqdn, null)

--- a/tests/unit/monitoring_names.tftest.hcl
+++ b/tests/unit/monitoring_names.tftest.hcl
@@ -31,6 +31,11 @@ run "short_cluster_names_keep_legacy_monitoring_names" {
   }
 
   assert {
+    condition     = output.data_collection_endpoint_name == module.monitoring[0].data_collection_endpoint_name
+    error_message = "The root module should expose the monitoring data collection endpoint name."
+  }
+
+  assert {
     condition     = module.monitoring[0].data_collection_rule_name == module.monitoring[0].data_collection_endpoint_name
     error_message = "The MSProm data collection rule should keep matching the data collection endpoint name."
   }
@@ -63,3 +68,4 @@ run "long_cluster_names_are_capped_for_monitoring_resources" {
     error_message = "The capped MSProm data collection endpoint name must not contain consecutive hyphens or end with a hyphen."
   }
 }
+

--- a/tests/unit/outputs.tftest.hcl
+++ b/tests/unit/outputs.tftest.hcl
@@ -48,4 +48,44 @@ run "restored_outputs_are_available" {
     condition     = output.node_resource_group_id == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg-test_test-aks_eastus"
     error_message = "node_resource_group_id should return the node resource group resource ID."
   }
+
+  assert {
+    condition     = output.data_collection_endpoint_id == null
+    error_message = "data_collection_endpoint_id should be null when monitoring is not onboarded."
+  }
+
+  assert {
+    condition     = output.data_collection_endpoint_name == null
+    error_message = "data_collection_endpoint_name should be null when monitoring is not onboarded."
+  }
+}
+
+run "monitoring_outputs_are_available" {
+  command = apply
+
+  variables {
+    addon_profile_oms_agent = {
+      enabled = true
+      config = {
+        log_analytics_workspace_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.OperationalInsights/workspaces/law-test"
+      }
+    }
+    azure_monitor_profile = {
+      metrics = {
+        enabled = true
+      }
+    }
+    onboard_monitoring      = true
+    prometheus_workspace_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Monitor/accounts/prom-test"
+  }
+
+  assert {
+    condition     = output.data_collection_endpoint_id == module.monitoring[0].data_collection_endpoint_id
+    error_message = "data_collection_endpoint_id should expose the monitoring submodule data collection endpoint ID."
+  }
+
+  assert {
+    condition     = output.data_collection_endpoint_name == "MSProm-eastus-test-aks"
+    error_message = "data_collection_endpoint_name should expose the monitoring submodule data collection endpoint name."
+  }
 }


### PR DESCRIPTION
Closes #228.

## Summary
- Exposes the monitoring submodule Data Collection Endpoint ID and name from the root module as `data_collection_endpoint_id` and `data_collection_endpoint_name`.
- Returns `null` for both root outputs when `onboard_monitoring` is disabled.
- Adds unit coverage for disabled monitoring and enabled monitoring pass-through behavior.
- Regenerates root README output documentation.

## Repro and validation
- Reproduced against the sandbox subscription by temporarily enabling managed Prometheus monitoring in the default example with `azure_monitor_profile`, `onboard_monitoring = true`, and `prometheus_workspace_id`.
- Confirmed the monitoring submodule created DCE `/subscriptions/d2c79ad4-f497-44b6-a2d7-e7477a6068cb/resourceGroups/rg-s953/providers/Microsoft.Insights/dataCollectionEndpoints/MSProm-northeurope-aks-s953`, while root outputs were empty before the fix.
- Verified after the fix via `terraform console` against the deployed state that `module.default.data_collection_endpoint_id` and `module.default.data_collection_endpoint_name` returned the DCE ID/name.
- Destroyed the temporary sandbox deployment; `az group exists --name rg-s953` returned `false`.

## Checks
- `PORCH_NO_TUI=1 ./avm tf-test-unit` passed.
- `PORCH_NO_TUI=1 ./avm pre-commit` passed.
- `PORCH_NO_TUI=1 ./avm pr-check` passed docs/mapotf/tflint stages, but the Well-Architected default example plan failed locally because the containerized AzureRM provider could not read the Azure CLI MSAL cache (`Run az login`). Local `az account get-access-token` succeeds, so this appears to be a local container auth boundary rather than a module failure.