### PR TITLE
chore: consolidate open dependency PRs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/examples/stateful-workloads/README.md
+++ b/examples/stateful-workloads/README.md
@@ -74,7 +74,7 @@ data "azurerm_client_config" "current" {}
 
 module "avm_res_keyvault_vault" {
   source  = "Azure/avm-res-keyvault-vault/azurerm"
-  version = "0.9.1"
+  version = "0.10.2"
 
   location            = azurerm_resource_group.this.location
   name                = coalesce(var.keyvault_name, module.naming.key_vault.name_unique)
@@ -95,7 +95,7 @@ module "avm_res_keyvault_vault" {
 # ######################################################################################################################
 module "avm_res_containerregistry_registry" {
   source  = "Azure/avm-res-containerregistry-registry/azurerm"
-  version = "0.4.0"
+  version = "0.5.1"
 
   location            = azurerm_resource_group.this.location
   name                = coalesce(var.acr_registry_name, module.naming.container_registry.name_unique)
@@ -496,13 +496,13 @@ The following Modules are called:
 
 Source: Azure/avm-res-containerregistry-registry/azurerm
 
-Version: 0.4.0
+Version: 0.5.1
 
 ### <a name="module_avm_res_keyvault_vault"></a> [avm\_res\_keyvault\_vault](#module\_avm\_res\_keyvault\_vault)
 
 Source: Azure/avm-res-keyvault-vault/azurerm
 
-Version: 0.9.1
+Version: 0.10.2
 
 ### <a name="module_mongodb"></a> [mongodb](#module\_mongodb)
 

--- a/examples/stateful-workloads/main.tf
+++ b/examples/stateful-workloads/main.tf
@@ -88,7 +88,7 @@ module "avm_res_keyvault_vault" {
 # ######################################################################################################################
 module "avm_res_containerregistry_registry" {
   source  = "Azure/avm-res-containerregistry-registry/azurerm"
-  version = "0.4.0"
+  version = "0.5.1"
 
   location            = azurerm_resource_group.this.location
   name                = coalesce(var.acr_registry_name, module.naming.container_registry.name_unique)

--- a/examples/stateful-workloads/main.tf
+++ b/examples/stateful-workloads/main.tf
@@ -67,7 +67,7 @@ data "azurerm_client_config" "current" {}
 
 module "avm_res_keyvault_vault" {
   source  = "Azure/avm-res-keyvault-vault/azurerm"
-  version = "0.9.1"
+  version = "0.10.2"
 
   location            = azurerm_resource_group.this.location
   name                = coalesce(var.keyvault_name, module.naming.key_vault.name_unique)


### PR DESCRIPTION
## Summary

Consolidates the current open dependency PRs into one branch:

- #230: bump `actions/checkout` from 6.0.3 to 7.0.0
- #231: bump `Azure/avm-res-keyvault-vault/azurerm` from 0.9.1 to 0.10.2 in `examples/stateful-workloads`
- #232: bump `Azure/avm-res-containerregistry-registry/azurerm` from 0.4.0 to 0.5.1 in `examples/stateful-workloads`

Also includes regenerated `examples/stateful-workloads/README.md` output from AVM pre-commit.

## Validation

- `PORCH_NO_TUI=1 .\avm pre-commit`
- `PORCH_NO_TUI=1 .\avm pr-check`