### PR TITLE
Expose Gateway API ingress profile fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -1219,9 +1219,14 @@ Default: `null`
 
 Description: Ingress profile for the container service cluster.
 
+- `gateway_api` - Settings for the managed Gateway API installation.
+  - `installation` - Configuration for the managed Gateway API installation. If not specified, the default is `Disabled`.
 - `web_app_routing` - Application Routing add-on settings for the ingress profile.
   - `dns_zone_resource_ids` - Resource IDs of the DNS zones to be associated with the Application Routing add-on. Used only when Application Routing add-on is enabled. Public and private DNS zones can be in different resource groups, but all public DNS zones must be in the same resource group and all private DNS zones must be in the same resource group.
   - `enabled` - Whether to enable the Application Routing add-on.
+  - `gateway_api_implementations` - Configurations for Gateway API providers to be used for managed ingress with App Routing.
+    - `app_routing_istio` - Configuration for using a sidecar-less Istio control plane for managed ingress via the Gateway API with App Routing.
+      - `mode` - Whether to enable Istio as a Gateway API implementation for managed ingress with App Routing.
   - `nginx` - The nginx property.
     - `default_ingress_controller_type` - Ingress type for the default NginxIngressController custom resource
 
@@ -1229,9 +1234,17 @@ Type:
 
 ```hcl
 object({
+    gateway_api = optional(object({
+      installation = optional(string)
+    }))
     web_app_routing = optional(object({
       dns_zone_resource_ids = optional(list(string))
       enabled               = optional(bool)
+      gateway_api_implementations = optional(object({
+        app_routing_istio = optional(object({
+          mode = optional(string)
+        }))
+      }))
       nginx = optional(object({
         default_ingress_controller_type = optional(string)
       }))

--- a/locals.resource_body.tf
+++ b/locals.resource_body.tf
@@ -98,9 +98,17 @@ locals {
         resourceId = value.resource_id
       } }
       ingressProfile = var.ingress_profile == null ? null : {
+        gatewayAPI = var.ingress_profile.gateway_api == null ? null : {
+          installation = var.ingress_profile.gateway_api.installation
+        }
         webAppRouting = var.ingress_profile.web_app_routing == null ? null : {
           dnsZoneResourceIds = var.ingress_profile.web_app_routing.dns_zone_resource_ids == null ? null : [for item in var.ingress_profile.web_app_routing.dns_zone_resource_ids : item]
           enabled            = var.ingress_profile.web_app_routing.enabled
+          gatewayAPIImplementations = var.ingress_profile.web_app_routing.gateway_api_implementations == null ? null : {
+            appRoutingIstio = var.ingress_profile.web_app_routing.gateway_api_implementations.app_routing_istio == null ? null : {
+              mode = var.ingress_profile.web_app_routing.gateway_api_implementations.app_routing_istio.mode
+            }
+          }
           nginx = var.ingress_profile.web_app_routing.nginx == null ? null : {
             defaultIngressControllerType = var.ingress_profile.web_app_routing.nginx.default_ingress_controller_type
           }

--- a/tests/unit/ingress_profile.tftest.hcl
+++ b/tests/unit/ingress_profile.tftest.hcl
@@ -1,0 +1,48 @@
+mock_provider "azapi" {}
+mock_provider "azurerm" {}
+mock_provider "modtm" {}
+mock_provider "random" {}
+
+variables {
+  location  = "eastus"
+  name      = "test-aks"
+  parent_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test"
+}
+
+run "gateway_api_fields_are_passed_through" {
+  command = plan
+
+  variables {
+    ingress_profile = {
+      gateway_api = {
+        installation = "Standard"
+      }
+      web_app_routing = {
+        enabled = true
+        gateway_api_implementations = {
+          app_routing_istio = {
+            mode = "Enabled"
+          }
+        }
+        nginx = {
+          default_ingress_controller_type = "None"
+        }
+      }
+    }
+  }
+
+  assert {
+    condition     = azapi_resource.this.body.properties.ingressProfile.gatewayAPI.installation == "Standard"
+    error_message = "Ingress profile should pass through the managed Gateway API installation setting."
+  }
+
+  assert {
+    condition     = azapi_resource.this.body.properties.ingressProfile.webAppRouting.gatewayAPIImplementations.appRoutingIstio.mode == "Enabled"
+    error_message = "Ingress profile should pass through the App Routing Istio Gateway API implementation setting."
+  }
+
+  assert {
+    condition     = azapi_resource.this.body.properties.ingressProfile.webAppRouting.nginx.defaultIngressControllerType == "None"
+    error_message = "Ingress profile should preserve the existing nginx setting when Gateway API fields are configured."
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -743,9 +743,17 @@ DESCRIPTION
 
 variable "ingress_profile" {
   type = object({
+    gateway_api = optional(object({
+      installation = optional(string)
+    }))
     web_app_routing = optional(object({
       dns_zone_resource_ids = optional(list(string))
       enabled               = optional(bool)
+      gateway_api_implementations = optional(object({
+        app_routing_istio = optional(object({
+          mode = optional(string)
+        }))
+      }))
       nginx = optional(object({
         default_ingress_controller_type = optional(string)
       }))
@@ -755,13 +763,27 @@ variable "ingress_profile" {
   description = <<DESCRIPTION
 Ingress profile for the container service cluster.
 
+- `gateway_api` - Settings for the managed Gateway API installation.
+  - `installation` - Configuration for the managed Gateway API installation. If not specified, the default is `Disabled`.
 - `web_app_routing` - Application Routing add-on settings for the ingress profile.
   - `dns_zone_resource_ids` - Resource IDs of the DNS zones to be associated with the Application Routing add-on. Used only when Application Routing add-on is enabled. Public and private DNS zones can be in different resource groups, but all public DNS zones must be in the same resource group and all private DNS zones must be in the same resource group.
   - `enabled` - Whether to enable the Application Routing add-on.
+  - `gateway_api_implementations` - Configurations for Gateway API providers to be used for managed ingress with App Routing.
+    - `app_routing_istio` - Configuration for using a sidecar-less Istio control plane for managed ingress via the Gateway API with App Routing.
+      - `mode` - Whether to enable Istio as a Gateway API implementation for managed ingress with App Routing.
   - `nginx` - The nginx property.
     - `default_ingress_controller_type` - Ingress type for the default NginxIngressController custom resource
 
 DESCRIPTION
+
+  validation {
+    condition     = var.ingress_profile == null || contains(["", "Disabled", "Standard"], coalesce(try(var.ingress_profile.gateway_api.installation, null), ""))
+    error_message = "ingress_profile.gateway_api.installation must be one of: [\"Disabled\", \"Standard\"]."
+  }
+  validation {
+    condition     = var.ingress_profile == null || contains(["", "Disabled", "Enabled"], coalesce(try(var.ingress_profile.web_app_routing.gateway_api_implementations.app_routing_istio.mode, null), ""))
+    error_message = "ingress_profile.web_app_routing.gateway_api_implementations.app_routing_istio.mode must be one of: [\"Disabled\", \"Enabled\"]."
+  }
 }
 
 variable "kind" {


### PR DESCRIPTION
## Summary
- Expose AKS managed Gateway API settings through `ingress_profile.gateway_api`.
- Expose App Routing Istio Gateway API implementation settings through `ingress_profile.web_app_routing.gateway_api_implementations.app_routing_istio`.
- Map the new snake_case inputs to the AKS `2026-03-01` request body and add unit coverage.

Fixes #234

## Validation
- `PORCH_NO_TUI=1 ./avm tf-test-unit`
- `PORCH_NO_TUI=1 ./avm pre-commit`
- `git diff --check`
- Live e2e from `/tmp/avm234-e2e-westus3`: apply succeeded, second apply was idempotent (`No changes`), and destroy completed cleanly.
- Live AKS `2026-03-01` API returned `gatewayAPI.installation = Standard` and `webAppRouting.gatewayAPIImplementations.appRoutingIstio.mode = Enabled`.