### PR TITLE
feat: add kube-proxy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1262,6 +1262,37 @@ Type: `string`
 
 Default: `null`
 
+### <a name="input_kube_proxy_config"></a> [kube\_proxy\_config](#input\_kube\_proxy\_config)
+
+Description: Kube-proxy configuration for the managed cluster. This AKS feature is in preview and requires the `Microsoft.ContainerService/KubeProxyConfigurationPreview` subscription feature.
+
+- `enabled` - (Required) Whether AKS deploys the managed `kube-proxy` DaemonSet. Disabling kube-proxy is supported only with BYO CNI (`network_profile.network_plugin = "none"`). To re-enable kube-proxy after disabling it, set this value to `true` and apply before removing the `kube_proxy_config` input.
+- `mode` - Proxy mode. Possible values are `IPTABLES`, `IPVS`, and `NFTABLES`.
+- `ipvs_config` - IPVS-specific settings. This can be specified only when `mode` is `IPVS`.
+  - `scheduler` - IPVS scheduler. Possible values are `LeastConnection` and `RoundRobin`.
+  - `tcp_fin_timeout_seconds` - Positive integer timeout for IPVS TCP sessions after receiving a FIN, in seconds.
+  - `tcp_timeout_seconds` - Positive integer timeout for idle IPVS TCP sessions, in seconds.
+  - `udp_timeout_seconds` - Positive integer timeout for IPVS UDP packets, in seconds.
+
+For more information, see <https://learn.microsoft.com/azure/aks/configure-kube-proxy>.
+
+Type:
+
+```hcl
+object({
+    enabled = bool
+    mode    = optional(string)
+    ipvs_config = optional(object({
+      scheduler               = optional(string)
+      tcp_fin_timeout_seconds = optional(number)
+      tcp_timeout_seconds     = optional(number)
+      udp_timeout_seconds     = optional(number)
+    }))
+  })
+```
+
+Default: `null`
+
 ### <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version)
 
 Description: The version of Kubernetes specified by the user. Both patch version <major.minor.patch> (e.g. 1.20.13) and <major.minor> (e.g. 1.20) are supported. When <major.minor> is specified, the latest supported GA patch version is chosen automatically. Updating the cluster with the same <major.minor> once it has been created (e.g. 1.14.x -> 1.14) will not trigger an upgrade, even if a newer patch version is available. When you upgrade a supported AKS cluster, Kubernetes minor versions cannot be skipped. All upgrades must be performed sequentially by major version number. For example, upgrades between 1.14.x -> 1.15.x or 1.15.x -> 1.16.x are allowed, however 1.14.x -> 1.16.x is not allowed. See [upgrading an AKS cluster](https://docs.microsoft.com/azure/aks/upgrade-cluster) for more details.

--- a/locals.network_profile.tf
+++ b/locals.network_profile.tf
@@ -2,8 +2,22 @@ locals {
   network_profile = (
     (local.is_automatic && try(var.network_profile.outbound_type == "loadBalancer", true))
     ||
-    local.network_profile_filtered == null
-  ) ? null : { for k, v in local.network_profile_filtered : k => v if v != null }
+    (local.network_profile_filtered == null && var.kube_proxy_config == null)
+    ) ? null : merge(
+    local.network_profile_filtered == null ? {} : { for k, v in local.network_profile_filtered : k => v if v != null },
+    var.kube_proxy_config == null ? {} : {
+      kubeProxyConfig = {
+        enabled = var.kube_proxy_config.enabled
+        mode    = var.kube_proxy_config.mode
+        ipvsConfig = var.kube_proxy_config.ipvs_config == null ? null : {
+          scheduler            = var.kube_proxy_config.ipvs_config.scheduler
+          tcpFinTimeoutSeconds = var.kube_proxy_config.ipvs_config.tcp_fin_timeout_seconds
+          tcpTimeoutSeconds    = var.kube_proxy_config.ipvs_config.tcp_timeout_seconds
+          udpTimeoutSeconds    = var.kube_proxy_config.ipvs_config.udp_timeout_seconds
+        }
+      }
+    }
+  )
   network_profile_filtered = var.network_profile == null ? null : { for k, v in local.network_profile_full : k => v if can(regex(local.network_profile_properties_regex, k)) && v != null }
   network_profile_full = var.network_profile == null ? null : {
     advancedNetworking = var.network_profile.advanced_networking == null ? null : {

--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,9 @@
 resource "azapi_resource" "this" {
-  location             = var.location
-  name                 = var.name
-  parent_id            = var.parent_id
-  type                 = "Microsoft.ContainerService/managedClusters@2026-03-01"
+  location  = var.location
+  name      = var.name
+  parent_id = var.parent_id
+  # kubeProxyConfig is not available in the stable 2026-03-01 API.
+  type                 = var.kube_proxy_config == null ? "Microsoft.ContainerService/managedClusters@2026-03-01" : "Microsoft.ContainerService/managedClusters@2026-03-02-preview"
   body                 = local.resource_body
   create_headers       = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   delete_headers       = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null

--- a/tests/unit/kube_proxy_config.tftest.hcl
+++ b/tests/unit/kube_proxy_config.tftest.hcl
@@ -1,0 +1,183 @@
+mock_provider "azapi" {}
+mock_provider "azurerm" {}
+mock_provider "modtm" {}
+mock_provider "random" {}
+
+variables {
+  location  = "eastus"
+  name      = "test-aks"
+  parent_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test"
+  network_profile = {
+    network_plugin = "none"
+  }
+}
+
+run "kube_proxy_config_omitted_when_null" {
+  command = plan
+
+  assert {
+    condition     = !can(azapi_resource.this.body.properties.networkProfile.kubeProxyConfig)
+    error_message = "networkProfile.kubeProxyConfig must be omitted from the payload when kube_proxy_config is null."
+  }
+
+  assert {
+    condition     = azapi_resource.this.type == "Microsoft.ContainerService/managedClusters@2026-03-01"
+    error_message = "The stable managed cluster API should remain the default when kube_proxy_config is null."
+  }
+}
+
+run "disabled_kube_proxy_config_is_serialized" {
+  command = plan
+
+  variables {
+    kube_proxy_config = {
+      enabled = false
+    }
+  }
+
+  assert {
+    condition     = azapi_resource.this.body.properties.networkProfile.kubeProxyConfig.enabled == false
+    error_message = "networkProfile.kubeProxyConfig.enabled should serialize false for BYO CNI."
+  }
+
+  assert {
+    condition     = azapi_resource.this.type == "Microsoft.ContainerService/managedClusters@2026-03-02-preview"
+    error_message = "Setting kube_proxy_config should opt the managed cluster into an API version that supports the preview property."
+  }
+}
+
+run "ipvs_kube_proxy_config_is_serialized" {
+  command = plan
+
+  variables {
+    kube_proxy_config = {
+      enabled = true
+      mode    = "IPVS"
+      ipvs_config = {
+        scheduler               = "LeastConnection"
+        tcp_fin_timeout_seconds = 120
+        tcp_timeout_seconds     = 900
+        udp_timeout_seconds     = 300
+      }
+    }
+  }
+
+  assert {
+    condition     = azapi_resource.this.body.properties.networkProfile.kubeProxyConfig.mode == "IPVS"
+    error_message = "networkProfile.kubeProxyConfig.mode should serialize the configured proxy mode."
+  }
+
+  assert {
+    condition     = azapi_resource.this.body.properties.networkProfile.kubeProxyConfig.ipvsConfig.scheduler == "LeastConnection"
+    error_message = "networkProfile.kubeProxyConfig.ipvsConfig.scheduler should serialize the configured scheduler."
+  }
+
+  assert {
+    condition     = azapi_resource.this.body.properties.networkProfile.kubeProxyConfig.ipvsConfig.tcpFinTimeoutSeconds == 120
+    error_message = "networkProfile.kubeProxyConfig.ipvsConfig should serialize timeout values using ARM property names."
+  }
+}
+
+run "invalid_kube_proxy_mode_is_rejected" {
+  command = plan
+
+  variables {
+    kube_proxy_config = {
+      enabled = true
+      mode    = "INVALID"
+    }
+  }
+
+  expect_failures = [
+    var.kube_proxy_config,
+  ]
+}
+
+run "invalid_ipvs_scheduler_is_rejected" {
+  command = plan
+
+  variables {
+    kube_proxy_config = {
+      enabled = true
+      mode    = "IPVS"
+      ipvs_config = {
+        scheduler = "INVALID"
+      }
+    }
+  }
+
+  expect_failures = [
+    var.kube_proxy_config,
+  ]
+}
+
+run "ipvs_config_requires_ipvs_mode" {
+  command = plan
+
+  variables {
+    kube_proxy_config = {
+      enabled = true
+      mode    = "IPTABLES"
+      ipvs_config = {
+        scheduler = "RoundRobin"
+      }
+    }
+  }
+
+  expect_failures = [
+    var.kube_proxy_config,
+  ]
+}
+
+run "non_positive_ipvs_timeout_is_rejected" {
+  command = plan
+
+  variables {
+    kube_proxy_config = {
+      enabled = true
+      mode    = "IPVS"
+      ipvs_config = {
+        tcp_timeout_seconds = 0
+      }
+    }
+  }
+
+  expect_failures = [
+    var.kube_proxy_config,
+  ]
+}
+
+run "disabling_kube_proxy_requires_byo_cni" {
+  command = plan
+
+  variables {
+    kube_proxy_config = {
+      enabled = false
+    }
+    network_profile = {
+      network_plugin = "azure"
+    }
+  }
+
+  expect_failures = [
+    var.kube_proxy_config,
+  ]
+}
+
+run "automatic_cluster_rejects_kube_proxy_config" {
+  command = plan
+
+  variables {
+    kube_proxy_config = {
+      enabled = true
+    }
+    sku = {
+      name = "Automatic"
+      tier = "Standard"
+    }
+  }
+
+  expect_failures = [
+    var.kube_proxy_config,
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -794,6 +794,64 @@ The kind of the managed cluster. This is only used to distinguish different type
 DESCRIPTION
 }
 
+variable "kube_proxy_config" {
+  type = object({
+    enabled = bool
+    mode    = optional(string)
+    ipvs_config = optional(object({
+      scheduler               = optional(string)
+      tcp_fin_timeout_seconds = optional(number)
+      tcp_timeout_seconds     = optional(number)
+      udp_timeout_seconds     = optional(number)
+    }))
+  })
+  default     = null
+  description = <<DESCRIPTION
+Kube-proxy configuration for the managed cluster. This AKS feature is in preview and requires the `Microsoft.ContainerService/KubeProxyConfigurationPreview` subscription feature.
+
+- `enabled` - (Required) Whether AKS deploys the managed `kube-proxy` DaemonSet. Disabling kube-proxy is supported only with BYO CNI (`network_profile.network_plugin = "none"`). To re-enable kube-proxy after disabling it, set this value to `true` and apply before removing the `kube_proxy_config` input.
+- `mode` - Proxy mode. Possible values are `IPTABLES`, `IPVS`, and `NFTABLES`.
+- `ipvs_config` - IPVS-specific settings. This can be specified only when `mode` is `IPVS`.
+  - `scheduler` - IPVS scheduler. Possible values are `LeastConnection` and `RoundRobin`.
+  - `tcp_fin_timeout_seconds` - Positive integer timeout for IPVS TCP sessions after receiving a FIN, in seconds.
+  - `tcp_timeout_seconds` - Positive integer timeout for idle IPVS TCP sessions, in seconds.
+  - `udp_timeout_seconds` - Positive integer timeout for IPVS UDP packets, in seconds.
+
+For more information, see <https://learn.microsoft.com/azure/aks/configure-kube-proxy>.
+DESCRIPTION
+
+  validation {
+    condition     = try(var.kube_proxy_config == null || var.kube_proxy_config.mode == null || contains(["IPTABLES", "IPVS", "NFTABLES"], var.kube_proxy_config.mode), true)
+    error_message = "kube_proxy_config.mode must be one of: [\"IPTABLES\", \"IPVS\", \"NFTABLES\"]."
+  }
+  validation {
+    condition     = try(var.kube_proxy_config == null || var.kube_proxy_config.ipvs_config == null || var.kube_proxy_config.ipvs_config.scheduler == null || contains(["LeastConnection", "RoundRobin"], var.kube_proxy_config.ipvs_config.scheduler), true)
+    error_message = "kube_proxy_config.ipvs_config.scheduler must be one of: [\"LeastConnection\", \"RoundRobin\"]."
+  }
+  validation {
+    condition     = var.kube_proxy_config == null || try(var.kube_proxy_config.ipvs_config, null) == null || try(var.kube_proxy_config.mode, null) == "IPVS"
+    error_message = "kube_proxy_config.ipvs_config can be specified only when kube_proxy_config.mode is \"IPVS\"."
+  }
+  validation {
+    condition = try(var.kube_proxy_config == null || var.kube_proxy_config.ipvs_config == null || alltrue([
+      for timeout in [
+        var.kube_proxy_config.ipvs_config.tcp_fin_timeout_seconds,
+        var.kube_proxy_config.ipvs_config.tcp_timeout_seconds,
+        var.kube_proxy_config.ipvs_config.udp_timeout_seconds,
+      ] : timeout == null ? true : timeout > 0 && timeout == floor(timeout)
+    ]), true)
+    error_message = "kube_proxy_config IPVS timeout values must be positive integers."
+  }
+  validation {
+    condition     = var.kube_proxy_config == null || try(var.kube_proxy_config.enabled, null) != false || try(var.network_profile.network_plugin, null) == "none"
+    error_message = "kube_proxy_config.enabled can be false only when network_profile.network_plugin is \"none\" for BYO CNI."
+  }
+  validation {
+    condition     = var.kube_proxy_config == null || try(var.sku.name, "Base") != "Automatic"
+    error_message = "kube_proxy_config is not supported for AKS Automatic clusters."
+  }
+}
+
 variable "kubernetes_version" {
   type        = string
   default     = null


### PR DESCRIPTION
## Description

Adds a typed `kube_proxy_config` input and maps it to `properties.networkProfile.kubeProxyConfig` so BYO CNI clusters can disable the AKS-managed `kube-proxy` DaemonSet.

The stable `2026-03-01` managed-cluster API rejects this preview property, so the module opts into `2026-03-02-preview` only when `kube_proxy_config` is set. Existing configurations remain on the stable API. The input validates proxy modes, IPVS settings, positive integer timeouts, BYO CNI requirements, and AKS Automatic incompatibility.

Sandbox validation covered the original behavior (`networkPlugin = none`, `kubeProxyConfig = null`, managed DaemonSet running), an in-place disable/re-enable cycle, fresh cluster creation with kube-proxy disabled, DaemonSet/pod absence, and an idempotent follow-up plan.

Closes #256

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks