### PR TITLE
fix: allow pod CIDR for Automatic clusters

### DIFF
--- a/locals.network_profile.tf
+++ b/locals.network_profile.tf
@@ -76,6 +76,7 @@ locals {
   network_profile_properties_automatic = [
     "dnsServiceIP",
     "outboundType",
+    "podCidr",
     "serviceCidr"
   ]
   network_profile_properties_regex           = local.is_automatic ? local.network_profile_properties_regex_automatic : local.network_profile_properties_regex_standard

--- a/tests/unit/automatic_payload.tftest.hcl
+++ b/tests/unit/automatic_payload.tftest.hcl
@@ -60,6 +60,7 @@ run "automatic_cluster_supported_profiles_are_passed_through" {
         enabled = true
       }
     }
+
     workload_auto_scaler_profile = {
       keda = {
         enabled = true
@@ -98,5 +99,37 @@ run "automatic_cluster_supported_profiles_are_passed_through" {
   assert {
     condition     = azapi_resource.this.body.properties.workloadAutoScalerProfile.keda.enabled == true
     error_message = "Automatic cluster payload should pass through workloadAutoScalerProfile."
+  }
+}
+
+run "automatic_cluster_pod_cidr_is_passed_through" {
+  command = plan
+
+  variables {
+    network_profile = {
+      outbound_type = "managedNATGateway"
+      pod_cidr      = "172.28.0.0/16"
+    }
+  }
+
+  assert {
+    condition     = azapi_resource.this.body.properties.networkProfile.podCidr == "172.28.0.0/16"
+    error_message = "Automatic cluster payload should pass through networkProfile.podCidr."
+  }
+}
+
+run "automatic_cluster_load_balancer_omits_network_profile" {
+  command = plan
+
+  variables {
+    network_profile = {
+      outbound_type = "loadBalancer"
+      pod_cidr      = "172.28.0.0/16"
+    }
+  }
+
+  assert {
+    condition     = !can(azapi_resource.this.body.properties.networkProfile)
+    error_message = "Automatic cluster payload should omit networkProfile when outboundType is loadBalancer."
   }
 }


### PR DESCRIPTION
## Summary

- allow Automatic AKS clusters to pass a caller-specified `networkProfile.podCidr`
- add unit coverage for the supported custom pod CIDR payload
- retain the existing guard that omits the entire network profile for Automatic clusters using `outboundType = "loadBalancer"`

## Live API evidence

A live Canada Central sandbox test using `Microsoft.ContainerService/managedClusters@2026-03-01` accepted `sku.name = "Automatic"` with `networkProfile.podCidr = "172.28.0.0/16"`. The deployed cluster persisted Azure CNI Overlay, Cilium, `managedNATGateway`, and both `podCidr`/`podCidrs` as `172.28.0.0/16`. A control Automatic cluster without `podCidr` received the default `10.244.0.0/16`, and a direct AzAPI Terraform configuration was idempotent after deployment.

A separate Automatic request using `outboundType = "loadBalancer"` was rejected with `AKSAutomaticSKUFeatureValidationError`, so this change intentionally preserves the existing whole-network-profile suppression for that combination.

## Tests

- `PORCH_NO_TUI=1 .\avm.ps1 tf-test-unit` - passed
- `PORCH_NO_TUI=1 .\avm.ps1 pre-commit` - passed
- `PORCH_NO_TUI=1 .\avm.ps1 pr-check` - local checks passed; the default example plan was blocked because the local Azure CLI account is missing from the MSAL token cache and requires `az login`

Closes #260