### PR TITLE
feat: expose ignore-pod-disruption-budget for AKS agent pool deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,11 @@ Kubelet configurations of agent nodes. See [AKS custom node configuration](https
 - `pod_max_pids` - The maximum number of processes per pod.
 - `topology_manager_policy` - The Topology Manager policy to use. For more information see [Kubernetes Topology Manager](https://kubernetes.io/docs/tasks/administer-cluster/topology-manager). The default is 'none'. Allowed values are 'none', 'best-effort', 'restricted', and 'single-numa-node'.
 
+**delete\_options**  
+Options applied only when deleting this agent pool.
+
+- `ignore_pod_disruption_budget` - Whether to delete the agent pool without honoring PodDisruptionBudgets. When enabled, the delete request includes `ignore-pod-disruption-budget=true`. This can cause service disruption and should be used only when deleting the pool is more important than preserving workload availability. For more information, see [Delete an Azure Kubernetes Service node pool](https://learn.microsoft.com/azure/aks/delete-node-pool).
+
 **os\_sku**  
 Specifies the OS SKU used by the agent pool. The default is Ubuntu if OSType is Linux. The default is Windows2019 when Kubernetes <= 1.24 or Windows2022 when Kubernetes >= 1.25 if OSType is Windows.
 
@@ -455,6 +460,9 @@ map(object({
     creation_data = optional(object({
       source_resource_id = optional(string)
     }))
+    delete_options = optional(object({
+      ignore_pod_disruption_budget = optional(bool, false)
+    }), {})
     enable_auto_scaling         = optional(bool)
     enable_encryption_at_host   = optional(bool)
     enable_fips                 = optional(bool)

--- a/main.agent_pool.tf
+++ b/main.agent_pool.tf
@@ -10,6 +10,7 @@ module "nodepools" {
   count_of                      = each.value.count_of
   create_before_destroy         = var.create_agentpools_before_destroy
   creation_data                 = each.value.creation_data
+  delete_options                = each.value.delete_options
   enable_auto_scaling           = each.value.enable_auto_scaling
   enable_encryption_at_host     = each.value.enable_encryption_at_host
   enable_fips                   = each.value.enable_fips

--- a/modules/agentpool/README.md
+++ b/modules/agentpool/README.md
@@ -105,6 +105,22 @@ object({
 
 Default: `null`
 
+### <a name="input_delete_options"></a> [delete\_options](#input\_delete\_options)
+
+Description: Options applied only when deleting this agent pool.
+
+- `ignore_pod_disruption_budget` - Whether to delete the agent pool without honoring PodDisruptionBudgets. When enabled, the delete request includes `ignore-pod-disruption-budget=true`. This can cause service disruption and should be used only when deleting the pool is more important than preserving workload availability. For more information, see [Delete an Azure Kubernetes Service node pool](https://learn.microsoft.com/azure/aks/delete-node-pool).
+
+Type:
+
+```hcl
+object({
+    ignore_pod_disruption_budget = optional(bool, false)
+  })
+```
+
+Default: `{}`
+
 ### <a name="input_enable_auto_scaling"></a> [enable\_auto\_scaling](#input\_enable\_auto\_scaling)
 
 Description: Whether to enable auto-scaler

--- a/modules/agentpool/main.tf
+++ b/modules/agentpool/main.tf
@@ -31,6 +31,10 @@ resource "azapi_resource" "this" {
   # Azure still validates the request at apply time.
   schema_validation_enabled = false
 
+  delete_query_parameters = var.delete_options.ignore_pod_disruption_budget ? {
+    "ignore-pod-disruption-budget" = ["true"]
+  } : null
+
   dynamic "timeouts" {
     for_each = var.timeouts == null ? [] : [var.timeouts]
 
@@ -65,6 +69,10 @@ resource "azapi_resource" "this_create_before_destroy" {
   # AzAPI's embedded AKS schema does not include this preview API yet.
   # Azure still validates the request at apply time.
   schema_validation_enabled = false
+
+  delete_query_parameters = var.delete_options.ignore_pod_disruption_budget ? {
+    "ignore-pod-disruption-budget" = ["true"]
+  } : null
 
   dynamic "timeouts" {
     for_each = var.timeouts == null ? [] : [var.timeouts]

--- a/modules/agentpool/variables.tf
+++ b/modules/agentpool/variables.tf
@@ -89,6 +89,19 @@ Data used when creating a target resource from a source resource.
 DESCRIPTION
 }
 
+variable "delete_options" {
+  type = object({
+    ignore_pod_disruption_budget = optional(bool, false)
+  })
+  default     = {}
+  nullable    = false
+  description = <<DESCRIPTION
+Options applied only when deleting this agent pool.
+
+- `ignore_pod_disruption_budget` - Whether to delete the agent pool without honoring PodDisruptionBudgets. When enabled, the delete request includes `ignore-pod-disruption-budget=true`. This can cause service disruption and should be used only when deleting the pool is more important than preserving workload availability. For more information, see [Delete an Azure Kubernetes Service node pool](https://learn.microsoft.com/azure/aks/delete-node-pool).
+DESCRIPTION
+}
+
 variable "enable_auto_scaling" {
   type        = bool
   default     = null

--- a/variables.agent_pool.tf
+++ b/variables.agent_pool.tf
@@ -9,6 +9,9 @@ variable "agent_pools" {
     creation_data = optional(object({
       source_resource_id = optional(string)
     }))
+    delete_options = optional(object({
+      ignore_pod_disruption_budget = optional(bool, false)
+    }), {})
     enable_auto_scaling         = optional(bool)
     enable_encryption_at_host   = optional(bool)
     enable_fips                 = optional(bool)
@@ -196,6 +199,11 @@ Kubelet configurations of agent nodes. See [AKS custom node configuration](https
 - `image_gc_low_threshold` - The percent of disk usage before which image garbage collection is never run. This cannot be set higher than imageGcHighThreshold. The default is 80%
 - `pod_max_pids` - The maximum number of processes per pod.
 - `topology_manager_policy` - The Topology Manager policy to use. For more information see [Kubernetes Topology Manager](https://kubernetes.io/docs/tasks/administer-cluster/topology-manager). The default is 'none'. Allowed values are 'none', 'best-effort', 'restricted', and 'single-numa-node'.
+
+**delete_options**
+Options applied only when deleting this agent pool.
+
+- `ignore_pod_disruption_budget` - Whether to delete the agent pool without honoring PodDisruptionBudgets. When enabled, the delete request includes `ignore-pod-disruption-budget=true`. This can cause service disruption and should be used only when deleting the pool is more important than preserving workload availability. For more information, see [Delete an Azure Kubernetes Service node pool](https://learn.microsoft.com/azure/aks/delete-node-pool).
 
 **os_sku**
 Specifies the OS SKU used by the agent pool. The default is Ubuntu if OSType is Linux. The default is Windows2019 when Kubernetes <= 1.24 or Windows2022 when Kubernetes >= 1.25 if OSType is Windows.


### PR DESCRIPTION
## Description

Expose the [AKS Agent Pools DELETE API option](https://learn.microsoft.com/en-us/rest/api/aks/agent-pools/delete?view=rest-aks-2026-01-01&tabs=HTTP) `ignore-pod-disruption-budget` through the module's `agent_pools` input.

The new interface is:

```hcl
delete_options = {
  ignore_pod_disruption_budget = true
}
```

When enabled, the module passes `ignore-pod-disruption-budget=true` to the Azure REST API for DELETE requests for the agent pool(s). This option is disabled by default to ensure PodDisruptionBudgets remain honored, thus preserving existing behavior.

Only `agent_pools` are affected, including both regular and create-before-destroy resource variants. The AKS default agent pool is part of the managed cluster resource and is not independently deleted through either resource.

### Validation performed

- Ran the AVM pre-commit checks successfully.
- Ran the AVM PR checks successfully.
- Validated the behavior using an AKS environment where PodDisruptionBudgets blocked node pool deletion. Enabling the option allowed the deletion to complete.


### Context

The Azure REST API [exposes an option to ignore PodDisruptionBudgets](https://learn.microsoft.com/en-us/rest/api/aks/agent-pools/delete?view=rest-aks-2026-01-01&tabs=HTTP) when deleting agent pools. This is also reflected by the `--ignore-pdb` parameter for the [Azure CLI node pool deletion operation](https://learn.microsoft.com/en-us/azure/aks/delete-node-pool?tabs=azure-cli#ignore-poddisruptionbudgets-pdbs-when-removing-an-existing-node-pool). The [azapi_resource](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource#delete_query_parameters-1) already allows passing such options via `delete_query_parameters`. As the AVM already uses the `azapi_resource` resource, it should expose the `ignore-pod-disruption-budget` option as well.
There is already a conceptually related solution for upgrades via this module's `upgrade_settings.override_settings.force_upgrade`, also allowing for ignoring PDBs (for example) via [Azure REST API](https://learn.microsoft.com/en-us/rest/api/aks/managed-clusters/create-or-update?view=rest-aks-2026-01-01&tabs=HTTP#upgradeoverridesettings). This feature provides the corresponding control for agent pool deletion, where Azure exposes the behavior as a DELETE query parameter instead.

### Dependencies

None.

### References

- [AKS Agent Pools DELETE REST API](https://learn.microsoft.com/en-us/rest/api/aks/agent-pools/delete?view=rest-aks-2026-01-01&tabs=HTTP)
- [AKS node pool deletion with Azure CLI](https://learn.microsoft.com/en-us/azure/aks/delete-node-pool?tabs=azure-cli#ignore-poddisruptionbudgets-pdbs-when-removing-an-existing-node-pool)

## Type of Change


- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

