### PR TITLE
fix: handle advanced networking profile type

### DIFF
--- a/locals.network_profile.tf
+++ b/locals.network_profile.tf
@@ -4,7 +4,7 @@ locals {
     ||
     (local.network_profile_filtered == null && var.kube_proxy_config == null)
     ) ? null : merge(
-    local.network_profile_filtered == null ? {} : { for k, v in local.network_profile_filtered : k => v if v != null },
+    try({ for k, v in local.network_profile_filtered : k => v if v != null }, {}),
     var.kube_proxy_config == null ? {} : {
       kubeProxyConfig = {
         enabled = var.kube_proxy_config.enabled

--- a/tests/unit/network_profile.tftest.hcl
+++ b/tests/unit/network_profile.tftest.hcl
@@ -1,0 +1,58 @@
+mock_provider "azapi" {}
+mock_provider "azurerm" {}
+mock_provider "modtm" {}
+mock_provider "random" {}
+
+variables {
+  location  = "westeurope"
+  name      = "test-aks"
+  parent_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test"
+}
+
+run "advanced_networking_is_serialized" {
+  command = plan
+
+  variables {
+    network_profile = {
+      outbound_type       = "userDefinedRouting"
+      dns_service_ip      = "192.168.129.10"
+      service_cidr        = "192.168.128.0/18"
+      pod_cidr            = "192.168.0.0/17"
+      network_plugin      = "azure"
+      network_plugin_mode = "overlay"
+      network_dataplane   = "cilium"
+      network_policy      = "cilium"
+      load_balancer_sku   = "standard"
+      advanced_networking = {
+        enabled = true
+        observability = {
+          enabled = true
+        }
+        security = {
+          enabled                   = true
+          advanced_network_policies = "FQDN"
+        }
+      }
+    }
+  }
+
+  assert {
+    condition     = azapi_resource.this.body.properties.networkProfile.advancedNetworking.enabled
+    error_message = "networkProfile.advancedNetworking.enabled should serialize true."
+  }
+
+  assert {
+    condition     = azapi_resource.this.body.properties.networkProfile.advancedNetworking.observability.enabled
+    error_message = "Advanced Networking observability should serialize as enabled."
+  }
+
+  assert {
+    condition     = azapi_resource.this.body.properties.networkProfile.advancedNetworking.security.enabled
+    error_message = "Advanced Networking security should serialize as enabled."
+  }
+
+  assert {
+    condition     = azapi_resource.this.body.properties.networkProfile.advancedNetworking.security.advancedNetworkPolicies == "FQDN"
+    error_message = "Advanced Networking security policies should serialize using the ARM property name."
+  }
+}


### PR DESCRIPTION
## Summary

- replace the incompatible empty-object conditional with a tightly scoped `try` fallback
- preserve the existing filtered network profile and kube-proxy merge behavior
- add regression coverage for the full nested Advanced Networking payload

## Validation

- reproduced the original `Inconsistent conditional result types` failure on Terraform 1.14.8 before the change
- passed the focused regression test and the complete AVM unit test suite
- passed `./avm pre-commit`
- deployed the fixed module to an isolated sandbox subscription and confirmed Azure persisted Advanced Networking observability, security, and `FQDN` policies
- confirmed a second Terraform plan reported `No changes`
- destroyed all 10 validation resources and removed the isolated Azure CLI token cache and Terraform state

`./avm pr-check` reached the deployment-example phase, but its `default` example plan required a fresh Azure login after the isolated validation credentials had already been deleted. The live deployment and idempotency validation above completed successfully.

Closes #263