### PR TITLE
fix: default agent pool versions to cluster version

### DIFF
--- a/examples/stateful-workloads/README.md
+++ b/examples/stateful-workloads/README.md
@@ -95,7 +95,7 @@ module "avm_res_keyvault_vault" {
 # ######################################################################################################################
 module "avm_res_containerregistry_registry" {
   source  = "Azure/avm-res-containerregistry-registry/azurerm"
-  version = "0.5.1"
+  version = "0.6.0"
 
   location            = azurerm_resource_group.this.location
   name                = coalesce(var.acr_registry_name, module.naming.container_registry.name_unique)
@@ -496,7 +496,7 @@ The following Modules are called:
 
 Source: Azure/avm-res-containerregistry-registry/azurerm
 
-Version: 0.5.1
+Version: 0.6.0
 
 ### <a name="module_avm_res_keyvault_vault"></a> [avm\_res\_keyvault\_vault](#module\_avm\_res\_keyvault\_vault)
 

--- a/main.agent_pool.tf
+++ b/main.agent_pool.tf
@@ -37,7 +37,7 @@ module "nodepools" {
   node_labels                   = each.value.node_labels
   node_public_ip_prefix_id      = each.value.node_public_ip_prefix_id
   node_taints                   = each.value.node_taints
-  orchestrator_version          = each.value.orchestrator_version
+  orchestrator_version          = each.value.orchestrator_version != null ? each.value.orchestrator_version : var.kubernetes_version
   os_disk_size_gb               = each.value.os_disk_size_gb
   os_disk_type                  = each.value.os_disk_type
   os_sku                        = each.value.os_sku

--- a/main.default_agent_pool.tf
+++ b/main.default_agent_pool.tf
@@ -34,7 +34,7 @@ module "default_agent_pool_data" {
   node_labels                   = var.default_agent_pool.node_labels
   node_public_ip_prefix_id      = var.default_agent_pool.node_public_ip_prefix_id
   node_taints                   = var.default_agent_pool.node_taints
-  orchestrator_version          = var.default_agent_pool.orchestrator_version
+  orchestrator_version          = var.default_agent_pool.orchestrator_version != null ? var.default_agent_pool.orchestrator_version : var.kubernetes_version
   os_disk_size_gb               = var.default_agent_pool.os_disk_size_gb
   os_disk_type                  = var.default_agent_pool.os_disk_type
   os_sku                        = var.default_agent_pool.os_sku

--- a/tests/unit/agent_pool_orchestrator_version.tftest.hcl
+++ b/tests/unit/agent_pool_orchestrator_version.tftest.hcl
@@ -1,0 +1,90 @@
+mock_provider "azapi" {}
+mock_provider "azurerm" {}
+mock_provider "modtm" {}
+mock_provider "random" {}
+
+variables {
+  location  = "eastus"
+  name      = "test-aks"
+  parent_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test"
+  sku = {
+    name = "Base"
+    tier = "Free"
+  }
+}
+
+run "agent_pool_versions_fall_back_to_kubernetes_version" {
+  command = plan
+
+  variables {
+    kubernetes_version = "1.34"
+    agent_pools = {
+      user = {
+        name             = "userpool"
+        output_data_only = true
+      }
+    }
+  }
+
+  assert {
+    condition     = azapi_resource.this.body.properties.agentPoolProfiles[0].orchestratorVersion == "1.34"
+    error_message = "The default agent pool orchestrator version should fall back to kubernetes_version."
+  }
+
+  assert {
+    condition     = module.nodepools["user"].body_properties.orchestratorVersion == "1.34"
+    error_message = "Additional agent pool orchestrator versions should fall back to kubernetes_version."
+  }
+}
+
+run "explicit_agent_pool_versions_take_precedence" {
+  command = plan
+
+  variables {
+    kubernetes_version = "1.34"
+    default_agent_pool = {
+      orchestrator_version = "1.33"
+    }
+    agent_pools = {
+      user = {
+        name                 = "userpool"
+        orchestrator_version = "1.32"
+        output_data_only     = true
+      }
+    }
+  }
+
+  assert {
+    condition     = azapi_resource.this.body.properties.agentPoolProfiles[0].orchestratorVersion == "1.33"
+    error_message = "An explicit default agent pool orchestrator version should override kubernetes_version."
+  }
+
+  assert {
+    condition     = module.nodepools["user"].body_properties.orchestratorVersion == "1.32"
+    error_message = "An explicit additional agent pool orchestrator version should override kubernetes_version."
+  }
+}
+
+run "null_versions_preserve_latest_semantics" {
+  command = plan
+
+  variables {
+    kubernetes_version = null
+    agent_pools = {
+      user = {
+        name             = "userpool"
+        output_data_only = true
+      }
+    }
+  }
+
+  assert {
+    condition     = try(azapi_resource.this.body.properties.agentPoolProfiles[0].orchestratorVersion, null) == null
+    error_message = "The default agent pool orchestrator version should remain null when kubernetes_version is null."
+  }
+
+  assert {
+    condition     = module.nodepools["user"].body_properties.orchestratorVersion == null
+    error_message = "Additional agent pool orchestrator versions should remain null when kubernetes_version is null."
+  }
+}


### PR DESCRIPTION
## Description

Closes #266

Defaults `default_agent_pool.orchestrator_version` and each additional agent pool's `orchestrator_version` to `kubernetes_version` when omitted. Explicit pool overrides still take precedence, and when both values are null the existing Azure latest-version semantics are preserved.

### Pre-fix qualification

- Current-main plan with `kubernetes_version = "1.34"` set the control plane to 1.34 but omitted `orchestratorVersion` from the default pool payload and sent null for the additional user pool.
- A minimal Free-tier deployment (one `Standard_D2s_v3` system node and a zero-count user pool) succeeded in `eastus2`; Azure resolved both pools to orchestrator version 1.34/current 1.34.9. This proved the requested explicit fallback is supported.

### Regional attempts

- `eastus` / `Standard_DC2ds_v3`: `AKSCapacityHeavyUsage` (prior attempt).
- `centralus` / `Standard_D2s_v3`: `AKSCapacityHeavyUsage`; failed attempt cleaned before rotation.
- `eastus2` / `Standard_D2s_v3`: pre-fix and post-fix deployments succeeded.

Regions were selected from current AKS 1.34 availability and subscription-visible VM SKU availability. `canadacentral` with `Standard_D2s_v5` was also identified as a fallback but was not needed after `eastus2` succeeded.

### Post-fix evidence

- The creation plan included `orchestratorVersion = "1.34"` for both default and additional pools without pool-specific inputs.
- Live apply succeeded; both pools reported orchestrator version 1.34/current 1.34.9 and `Succeeded`.
- Follow-up Terraform plan reported no changes.
- Unit coverage verifies fallback, explicit overrides, and null/latest behavior.
- All issue-266 resource groups and tagged resources were destroyed and verified absent.

### Validation

- `PORCH_NO_TUI=1 ./avm tf-test-unit` — passed
- `PORCH_NO_TUI=1 ./avm pre-commit` — passed
- `PORCH_NO_TUI=1 ./avm pr-check` — passed

### Caveat

Pre-commit refreshed the generated stateful-workloads README from container registry module 0.5.1 to the already-pinned 0.6.0; this generated update was required for the docs gate.

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all pre-commit checks