### PR TITLE
feat!: migrate remaining interfaces to AzAPI

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -20,7 +20,7 @@ The final plan must not replace the role assignment. Repeat the import for every
 
 The lock, role assignment, and diagnostic setting states move automatically. Private endpoints require explicit state adoption because one legacy `azurerm_private_endpoint` state object can contain both the endpoint and its private DNS zone group, while AzAPI manages those as two resources.
 
-For each private endpoint, first record its Azure resource ID, then remove only the legacy Terraform state entries. These commands do not delete Azure resources:
+Update the module source to 0.8.0 and run `terraform init -upgrade`, but do not plan or apply yet. For each private endpoint, first record its Azure resource ID, then remove only the legacy Terraform state entries. These commands do not delete Azure resources:
 
 ```shell
 terraform state rm 'module.<module>.azurerm_private_endpoint_application_security_group_association.this["<pe-key>-<asg-key>"]'
@@ -29,6 +29,6 @@ terraform import 'module.<module>.azapi_resource.private_endpoints["<pe-key>"]' 
 terraform import 'module.<module>.azapi_resource.private_dns_zone_groups["<pe-key>"]' '<private-endpoint-resource-id>/privateDnsZoneGroups/<dns-zone-group-name>'
 ```
 
-For an endpoint created with `private_endpoints_manage_dns_zone_group = false`, use the corresponding `this_unmanaged_dns_zone_groups` address and omit the private DNS zone group import.
+Omit the ASG command when the endpoint has no ASG associations. For an endpoint created with `private_endpoints_manage_dns_zone_group = false`, use the corresponding `this_unmanaged_dns_zone_groups` address and omit the private DNS zone group import. Also omit that import when the endpoint has no `private_dns_zone_resource_ids`.
 
 Run `terraform plan` after all imports. Do not apply if Terraform proposes deleting or replacing the managed cluster, lock, role assignment, diagnostic setting, private endpoint, DNS zone group, or ASG association.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,11 +2,11 @@
 
 The migration of locks, role assignments, diagnostic settings, and private endpoints to AzAPI is staged so existing Azure resources can be retained.
 
-## Prepare on 0.7.x
+## Prepare on 0.7.3
 
 The preparation release keeps the AzureRM resources but uses `Azure/avm-utl-interfaces/azure` to retain each role assignment's UUID and adapts the existing `diagnostic_settings` input to the AVM v2 diagnostic schema.
 
-After updating the module source and running `terraform init -upgrade`, adopt every existing role assignment UUID into the utility module before applying. Replace `<module>` and `<key>` with the module call and map key:
+After updating the module source to 0.7.3 and running `terraform init -upgrade`, adopt every existing role assignment UUID into the utility module before applying. Replace `<module>` and `<key>` with the module call and map key:
 
 ```shell
 terraform state show 'module.<module>.azurerm_role_assignment.this["<key>"]'
@@ -23,12 +23,13 @@ The lock, role assignment, and diagnostic setting states move automatically. Pri
 Update the module source to 0.8.0 and run `terraform init -upgrade`, but do not plan or apply yet. For each private endpoint, first record its Azure resource ID, then remove only the legacy Terraform state entries. These commands do not delete Azure resources:
 
 ```shell
+terraform state show 'module.<module>.azurerm_private_endpoint.this_managed_dns_zone_groups["<pe-key>"]'
 terraform state rm 'module.<module>.azurerm_private_endpoint_application_security_group_association.this["<pe-key>-<asg-key>"]'
 terraform state rm 'module.<module>.azurerm_private_endpoint.this_managed_dns_zone_groups["<pe-key>"]'
 terraform import 'module.<module>.azapi_resource.private_endpoints["<pe-key>"]' '<private-endpoint-resource-id>'
 terraform import 'module.<module>.azapi_resource.private_dns_zone_groups["<pe-key>"]' '<private-endpoint-resource-id>/privateDnsZoneGroups/<dns-zone-group-name>'
 ```
 
-Omit the ASG command when the endpoint has no ASG associations. For an endpoint created with `private_endpoints_manage_dns_zone_group = false`, use the corresponding `this_unmanaged_dns_zone_groups` address and omit the private DNS zone group import. Also omit that import when the endpoint has no `private_dns_zone_resource_ids`.
+Repeat the ASG state removal for every association, or omit it when the endpoint has no ASG associations. For an endpoint created with `private_endpoints_manage_dns_zone_group = false`, use the corresponding `this_unmanaged_dns_zone_groups` address in the `state show` and `state rm` commands and omit the private DNS zone group import. Also omit that import when the endpoint has no `private_dns_zone_resource_ids`.
 
 Run `terraform plan` after all imports. Do not apply if Terraform proposes deleting or replacing the managed cluster, lock, role assignment, diagnostic setting, private endpoint, DNS zone group, or ASG association.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.46.0, < 5.0.0)
-
 - <a name="requirement_modtm"></a> [modtm](#requirement\_modtm) (~> 0.3)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (>= 3.5.0, < 4.0.0)
@@ -23,17 +21,16 @@ The following requirements are needed by this module:
 
 The following resources are used by this module:
 
+- [azapi_resource.diagnostic_settings](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
+- [azapi_resource.lock](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
+- [azapi_resource.private_dns_zone_groups](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
+- [azapi_resource.private_endpoints](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
+- [azapi_resource.role_assignments](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
 - [azapi_resource.this](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
 - [azapi_resource_action.this_admin_kubeconfig](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource_action) (resource)
 - [azapi_resource_action.this_user_kubeconfig](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource_action) (resource)
 - [azapi_update_resource.default_agent_pool](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/update_resource) (resource)
 - [azapi_update_resource.kubernetes_version](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/update_resource) (resource)
-- [azurerm_management_lock.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_lock) (resource)
-- [azurerm_monitor_diagnostic_setting.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) (resource)
-- [azurerm_private_endpoint.this_managed_dns_zone_groups](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) (resource)
-- [azurerm_private_endpoint.this_unmanaged_dns_zone_groups](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) (resource)
-- [azurerm_private_endpoint_application_security_group_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint_application_security_group_association) (resource)
-- [azurerm_role_assignment.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) (resource)
 - [modtm_telemetry.telemetry](https://registry.terraform.io/providers/azure/modtm/latest/docs/resources/telemetry) (resource)
 - [random_string.dns_prefix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) (resource)
 - [random_uuid.telemetry](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) (resource)

--- a/locals.tf
+++ b/locals.tf
@@ -8,14 +8,5 @@ locals {
       }
     } : {}
   }
-  private_endpoint_application_security_group_associations = { for assoc in flatten([
-    for pe_k, pe_v in var.private_endpoints : [
-      for asg_k, asg_v in pe_v.application_security_group_associations : {
-        asg_key         = asg_k
-        pe_key          = pe_k
-        asg_resource_id = asg_v
-      }
-    ]
-  ]) : "${assoc.pe_key}-${assoc.asg_key}" => assoc }
   role_definition_resource_substring = "/providers/Microsoft.Authorization/roleDefinitions"
 }

--- a/main.diagnostic.tf
+++ b/main.diagnostic.tf
@@ -1,35 +1,27 @@
-resource "azurerm_monitor_diagnostic_setting" "this" {
-  for_each = var.diagnostic_settings
+resource "azapi_resource" "diagnostic_settings" {
+  for_each = module.interfaces.diagnostic_settings_azapi_v2
 
-  name                           = each.value.name != null ? each.value.name : "diag-${var.name}"
-  target_resource_id             = azapi_resource.this.id
-  eventhub_authorization_rule_id = each.value.event_hub_authorization_rule_resource_id
-  eventhub_name                  = each.value.event_hub_name
-  log_analytics_destination_type = each.value.log_analytics_destination_type
-  log_analytics_workspace_id     = each.value.workspace_resource_id
-  partner_solution_id            = each.value.marketplace_partner_resource_id
-  storage_account_id             = each.value.storage_account_resource_id
+  name                      = coalesce(each.value.name, "diag-${var.name}")
+  parent_id                 = azapi_resource.this.id
+  type                      = each.value.type
+  body                      = each.value.body
+  create_headers            = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  delete_headers            = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_null_property      = true
+  read_headers              = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  replace_triggers_refs     = []
+  response_export_values    = []
+  schema_validation_enabled = false
+  update_headers            = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 
-  dynamic "enabled_log" {
-    for_each = each.value.log_categories
-
-    content {
-      category = enabled_log.value
-    }
-  }
-  dynamic "enabled_log" {
-    for_each = each.value.log_groups
+  dynamic "timeouts" {
+    for_each = var.cluster_timeouts == null ? [] : [var.cluster_timeouts]
 
     content {
-      category_group = enabled_log.value
-    }
-  }
-
-  dynamic "metric" {
-    for_each = each.value.metric_categories
-
-    content {
-      category = metric.value
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
     }
   }
 }

--- a/main.interfaces.tf
+++ b/main.interfaces.tf
@@ -7,18 +7,28 @@ locals {
           for category in diagnostic_setting.log_categories : {
             category       = category
             category_group = null
+            enabled        = true
           }
         ],
         [
           for category_group in diagnostic_setting.log_groups : {
             category       = null
             category_group = category_group
+            enabled        = true
+          }
+        ],
+        [
+          for category_group in setsubtract(toset(["allLogs", "audit"]), diagnostic_setting.log_groups) : {
+            category       = null
+            category_group = category_group
+            enabled        = false
           }
         ]
       )
       metrics = [
         for category in diagnostic_setting.metric_categories : {
           category = category
+          enabled  = true
         }
       ]
       event_hub_authorization_rule_resource_id = diagnostic_setting.event_hub_authorization_rule_resource_id
@@ -29,6 +39,32 @@ locals {
       workspace_resource_id                    = diagnostic_setting.workspace_resource_id
     }
   }
+  private_endpoints = {
+    for key, private_endpoint in var.private_endpoints : key => {
+      application_security_group_associations = private_endpoint.application_security_group_associations
+      ip_configurations = {
+        for ip_configuration_key, ip_configuration in private_endpoint.ip_configurations :
+        ip_configuration_key => merge(ip_configuration, {
+          member_name = "management"
+        })
+      }
+      location                      = private_endpoint.location
+      lock                          = null
+      name                          = coalesce(private_endpoint.name, "pe-${var.name}")
+      network_interface_name        = private_endpoint.network_interface_name
+      private_dns_zone_group_name   = private_endpoint.private_dns_zone_group_name
+      private_dns_zone_resource_ids = private_endpoint.private_dns_zone_resource_ids
+      private_service_connection_name = coalesce(
+        private_endpoint.private_service_connection_name,
+        "pse-${var.name}"
+      )
+      resource_group_name = private_endpoint.resource_group_name
+      role_assignments    = {}
+      subnet_resource_id  = private_endpoint.subnet_resource_id
+      subresource_name    = "management"
+      tags                = private_endpoint.tags
+    }
+  }
   role_assignment_definition_scope = "/subscriptions/${split("/", var.parent_id)[2]}"
 }
 
@@ -36,9 +72,12 @@ module "interfaces" {
   source  = "Azure/avm-utl-interfaces/azure"
   version = "0.6.0"
 
-  diagnostic_settings_v2 = local.diagnostic_settings_v2
-  enable_telemetry       = var.enable_telemetry
-  lock                   = var.lock
+  diagnostic_settings_v2                  = local.diagnostic_settings_v2
+  enable_telemetry                        = var.enable_telemetry
+  lock                                    = var.lock
+  private_endpoints                       = local.private_endpoints
+  private_endpoints_manage_dns_zone_group = var.private_endpoints_manage_dns_zone_group
+  private_endpoints_scope                 = azapi_resource.this.id
   role_assignment_definition_lookup_enabled = anytrue([
     for role_assignment in var.role_assignments :
     !strcontains(lower(role_assignment.role_definition_id_or_name), lower(local.role_definition_resource_substring))

--- a/main.privateendpoint.tf
+++ b/main.privateendpoint.tf
@@ -1,80 +1,89 @@
-resource "azurerm_private_endpoint" "this_managed_dns_zone_groups" {
-  for_each = { for k, v in var.private_endpoints : k => v if var.private_endpoints_manage_dns_zone_group }
+resource "azapi_resource" "private_endpoints" {
+  for_each = module.interfaces.private_endpoints_azapi
 
-  location                      = each.value.location != null ? each.value.location : var.location
-  name                          = each.value.name != null ? each.value.name : "pe-${var.name}"
-  resource_group_name           = coalesce(each.value.resource_group_name, basename(var.parent_id))
-  subnet_id                     = each.value.subnet_resource_id
-  custom_network_interface_name = each.value.network_interface_name
-  tags                          = each.value.tags
-
-  private_service_connection {
-    is_manual_connection           = false
-    name                           = each.value.private_service_connection_name != null ? each.value.private_service_connection_name : "pse-${var.name}"
-    private_connection_resource_id = azapi_resource.this.id
-    subresource_names              = ["management"]
+  location = coalesce(var.private_endpoints[each.key].location, var.location)
+  name     = each.value.name
+  parent_id = var.private_endpoints[each.key].resource_group_name == null ? var.parent_id : format(
+    "/subscriptions/%s/resourceGroups/%s",
+    split("/", var.parent_id)[2],
+    var.private_endpoints[each.key].resource_group_name
+  )
+  type = each.value.type
+  body = merge(each.value.body, {
+    properties = merge(each.value.body.properties, {
+      customNetworkInterfaceName = var.private_endpoints[each.key].network_interface_name
+    })
+  })
+  create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_null_property   = true
+  read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  replace_triggers_refs  = ["properties.subnet.id"]
+  response_export_values = []
+  retry = {
+    error_message_regex  = ["ScopeLocked"]
+    interval_seconds     = 15
+    max_interval_seconds = 60
   }
+  schema_validation_enabled = false
+  tags                      = each.value.tags
+  update_headers            = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 
-  dynamic "ip_configuration" {
-    for_each = each.value.ip_configurations
+  dynamic "timeouts" {
+    for_each = var.cluster_timeouts == null ? [] : [var.cluster_timeouts]
 
     content {
-      name               = ip_configuration.value.name
-      private_ip_address = ip_configuration.value.private_ip_address
-      member_name        = "management"
-      subresource_name   = "management"
-    }
-  }
-
-  dynamic "private_dns_zone_group" {
-    for_each = length(each.value.private_dns_zone_resource_ids) > 0 ? ["this"] : []
-
-    content {
-      name                 = each.value.private_dns_zone_group_name
-      private_dns_zone_ids = each.value.private_dns_zone_resource_ids
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
     }
   }
 }
 
-# The PE resource when we are managing **not** the private_dns_zone_group block
-# An example use case is customers using Azure Policy to create private DNS zones
-# e.g. <https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/private-link-and-dns-integration-at-scale>
-resource "azurerm_private_endpoint" "this_unmanaged_dns_zone_groups" {
-  for_each = { for k, v in var.private_endpoints : k => v if !var.private_endpoints_manage_dns_zone_group }
-
-  location                      = each.value.location != null ? each.value.location : var.location
-  name                          = each.value.name != null ? each.value.name : "pe-${var.name}"
-  resource_group_name           = coalesce(each.value.resource_group_name, basename(var.parent_id))
-  subnet_id                     = each.value.subnet_resource_id
-  custom_network_interface_name = each.value.network_interface_name
-  tags                          = each.value.tags
-
-  private_service_connection {
-    is_manual_connection           = false
-    name                           = each.value.private_service_connection_name != null ? each.value.private_service_connection_name : "pse-${var.name}"
-    private_connection_resource_id = azapi_resource.this.id
-    subresource_names              = ["management"]
+resource "azapi_resource" "private_dns_zone_groups" {
+  for_each = {
+    for key, private_dns_zone_group in module.interfaces.private_dns_zone_groups_azapi :
+    key => private_dns_zone_group if length(var.private_endpoints[key].private_dns_zone_resource_ids) > 0
   }
 
-  dynamic "ip_configuration" {
-    for_each = each.value.ip_configurations
+  name      = each.value.name
+  parent_id = azapi_resource.private_endpoints[each.key].id
+  type      = each.value.type
+  body = merge(each.value.body, {
+    properties = merge(each.value.body.properties, {
+      privateDnsZoneConfigs = [
+        for private_dns_zone_resource_id in var.private_endpoints[each.key].private_dns_zone_resource_ids : {
+          name = basename(private_dns_zone_resource_id)
+          properties = {
+            privateDnsZoneId = private_dns_zone_resource_id
+          }
+        }
+      ]
+    })
+  })
+  create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_null_property   = true
+  read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  replace_triggers_refs  = []
+  response_export_values = []
+  retry = {
+    error_message_regex  = ["ScopeLocked"]
+    interval_seconds     = 15
+    max_interval_seconds = 60
+  }
+  schema_validation_enabled = false
+  update_headers            = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+
+  dynamic "timeouts" {
+    for_each = var.cluster_timeouts == null ? [] : [var.cluster_timeouts]
 
     content {
-      name               = ip_configuration.value.name
-      private_ip_address = ip_configuration.value.private_ip_address
-      member_name        = "management"
-      subresource_name   = "management"
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
     }
   }
-
-  lifecycle {
-    ignore_changes = [private_dns_zone_group]
-  }
-}
-
-resource "azurerm_private_endpoint_application_security_group_association" "this" {
-  for_each = local.private_endpoint_application_security_group_associations
-
-  application_security_group_id = each.value.asg_resource_id
-  private_endpoint_id           = var.private_endpoints_manage_dns_zone_group ? azurerm_private_endpoint.this_managed_dns_zone_groups[each.value.pe_key].id : azurerm_private_endpoint.this_unmanaged_dns_zone_groups[each.value.pe_key].id
 }

--- a/main.tf
+++ b/main.tf
@@ -97,27 +97,68 @@ moved {
   to   = azapi_resource.this
 }
 
-# required AVM resources interfaces
-resource "azurerm_management_lock" "this" {
+# required AVM resource interfaces
+resource "azapi_resource" "lock" {
   count = var.lock != null ? 1 : 0
 
-  lock_level = var.lock.kind
-  name       = coalesce(var.lock.name, "lock-${var.lock.kind}")
-  scope      = azapi_resource.this.id
-  notes      = var.lock.kind == "CanNotDelete" ? "Cannot delete the resource or its child resources." : "Cannot delete or modify the resource or its child resources."
+  name      = coalesce(module.interfaces.lock_azapi.name, "lock-${var.lock.kind}")
+  parent_id = azapi_resource.this.id
+  type      = module.interfaces.lock_azapi.type
+  body = merge(module.interfaces.lock_azapi.body, {
+    properties = merge(module.interfaces.lock_azapi.body.properties, {
+      notes = var.lock.kind == "CanNotDelete" ? "Cannot delete the resource or its child resources." : "Cannot delete or modify the resource or its child resources."
+    })
+  })
+  create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  replace_triggers_refs  = []
+  response_export_values = []
+  update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+
+  dynamic "timeouts" {
+    for_each = var.cluster_timeouts == null ? [] : [var.cluster_timeouts]
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
+
+  depends_on = [
+    azapi_resource.diagnostic_settings,
+    azapi_resource.private_dns_zone_groups,
+    azapi_resource.role_assignments,
+  ]
 }
 
-resource "azurerm_role_assignment" "this" {
-  for_each = var.role_assignments
+resource "azapi_resource" "role_assignments" {
+  for_each = module.interfaces.role_assignments_azapi
 
-  principal_id                           = each.value.principal_id
-  scope                                  = azapi_resource.this.id
-  condition                              = each.value.condition
-  condition_version                      = each.value.condition_version
-  delegated_managed_identity_resource_id = each.value.delegated_managed_identity_resource_id
-  name                                   = module.interfaces.role_assignments_azapi[each.key].name
-  role_definition_id                     = module.interfaces.role_assignments_azapi[each.key].body.properties.roleDefinitionId
-  skip_service_principal_aad_check       = each.value.skip_service_principal_aad_check
+  name                   = each.value.name
+  parent_id              = azapi_resource.this.id
+  type                   = each.value.type
+  body                   = each.value.body
+  create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_null_property   = true
+  read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  replace_triggers_refs  = []
+  response_export_values = []
+  update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+
+  dynamic "timeouts" {
+    for_each = var.cluster_timeouts == null ? [] : [var.cluster_timeouts]
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 }
 
 resource "azapi_resource_action" "this_user_kubeconfig" {

--- a/moved.interfaces.tf
+++ b/moved.interfaces.tf
@@ -1,0 +1,14 @@
+moved {
+  from = azurerm_management_lock.this
+  to   = azapi_resource.lock
+}
+
+moved {
+  from = azurerm_role_assignment.this
+  to   = azapi_resource.role_assignments
+}
+
+moved {
+  from = azurerm_monitor_diagnostic_setting.this
+  to   = azapi_resource.diagnostic_settings
+}

--- a/terraform.tf
+++ b/terraform.tf
@@ -6,10 +6,6 @@ terraform {
       source  = "Azure/azapi"
       version = "~> 2.9"
     }
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = ">= 4.46.0, < 5.0.0"
-    }
     modtm = {
       source  = "azure/modtm"
       version = "~> 0.3"

--- a/tests/unit/addon_profiles.tftest.hcl
+++ b/tests/unit/addon_profiles.tftest.hcl
@@ -1,5 +1,4 @@
 mock_provider "azapi" {}
-mock_provider "azurerm" {}
 mock_provider "modtm" {}
 mock_provider "random" {}
 

--- a/tests/unit/agent_pool_orchestrator_version.tftest.hcl
+++ b/tests/unit/agent_pool_orchestrator_version.tftest.hcl
@@ -1,5 +1,4 @@
 mock_provider "azapi" {}
-mock_provider "azurerm" {}
 mock_provider "modtm" {}
 mock_provider "random" {}
 

--- a/tests/unit/agent_pool_upgrade_settings_types.tftest.hcl
+++ b/tests/unit/agent_pool_upgrade_settings_types.tftest.hcl
@@ -1,5 +1,4 @@
 mock_provider "azapi" {}
-mock_provider "azurerm" {}
 mock_provider "modtm" {}
 mock_provider "random" {}
 

--- a/tests/unit/automatic_payload.tftest.hcl
+++ b/tests/unit/automatic_payload.tftest.hcl
@@ -1,5 +1,4 @@
 mock_provider "azapi" {}
-mock_provider "azurerm" {}
 mock_provider "modtm" {}
 mock_provider "random" {}
 

--- a/tests/unit/dns_prefix.tftest.hcl
+++ b/tests/unit/dns_prefix.tftest.hcl
@@ -1,5 +1,4 @@
 mock_provider "azapi" {}
-mock_provider "azurerm" {}
 mock_provider "modtm" {}
 mock_provider "random" {}
 

--- a/tests/unit/hosted_system_profile.tftest.hcl
+++ b/tests/unit/hosted_system_profile.tftest.hcl
@@ -1,5 +1,4 @@
 mock_provider "azapi" {}
-mock_provider "azurerm" {}
 mock_provider "modtm" {}
 mock_provider "random" {}
 

--- a/tests/unit/ingress_profile.tftest.hcl
+++ b/tests/unit/ingress_profile.tftest.hcl
@@ -1,5 +1,4 @@
 mock_provider "azapi" {}
-mock_provider "azurerm" {}
 mock_provider "modtm" {}
 mock_provider "random" {}
 

--- a/tests/unit/interfaces_migration.tftest.hcl
+++ b/tests/unit/interfaces_migration.tftest.hcl
@@ -102,13 +102,28 @@ run "private_endpoint_payload_preserves_legacy_identity" {
   command = plan
 
   assert {
+    condition     = azapi_resource.private_endpoints["primary"].name == "pe-test"
+    error_message = "The private endpoint must preserve an explicitly configured name."
+  }
+
+  assert {
     condition     = azapi_resource.private_endpoints["primary"].body.properties.customNetworkInterfaceName == "nic-test"
     error_message = "The private endpoint must preserve an explicitly configured NIC name."
   }
 
   assert {
+    condition     = azapi_resource.private_endpoints["primary"].body.properties.privateLinkServiceConnections[0].name == "pse-test-aks"
+    error_message = "The private endpoint must preserve the legacy default connection name."
+  }
+
+  assert {
     condition     = azapi_resource.private_endpoints["primary"].body.properties.applicationSecurityGroups[0].id == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationSecurityGroups/asg-test"
     error_message = "The private endpoint payload must retain ASG associations."
+  }
+
+  assert {
+    condition     = azapi_resource.private_dns_zone_groups["primary"].name == "default"
+    error_message = "The private DNS zone group must preserve its configured name."
   }
 
   assert {

--- a/tests/unit/interfaces_migration.tftest.hcl
+++ b/tests/unit/interfaces_migration.tftest.hcl
@@ -19,7 +19,6 @@ mock_provider "azapi" {
     }
   }
 }
-mock_provider "azurerm" {}
 mock_provider "modtm" {}
 mock_provider "random" {
   mock_resource "random_uuid" {
@@ -40,6 +39,22 @@ variables {
       log_groups            = []
       metric_categories     = ["AllMetrics"]
       workspace_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.OperationalInsights/workspaces/law-test"
+    }
+  }
+  lock = {
+    kind = "CanNotDelete"
+    name = "lock-test"
+  }
+  private_endpoints = {
+    primary = {
+      application_security_group_associations = {
+        primary = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationSecurityGroups/asg-test"
+      }
+      name                          = "pe-test"
+      network_interface_name        = "nic-test"
+      private_dns_zone_group_name   = "default"
+      private_dns_zone_resource_ids = ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/privateDnsZones/privatelink.eastus.azmk8s.io"]
+      subnet_resource_id            = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/snet-test"
     }
   }
   role_assignments = {
@@ -67,13 +82,46 @@ run "legacy_diagnostics_are_adapted_to_v2" {
     condition     = module.interfaces.diagnostic_settings_azapi_v2["primary"].body.properties.metrics[0].category == "AllMetrics"
     error_message = "The adapter must map legacy metric categories to v2 metric entries."
   }
+
+  assert {
+    condition     = one([for log in module.interfaces.diagnostic_settings_azapi_v2["primary"].body.properties.logs : log.enabled if log.categoryGroup == "audit"]) == false
+    error_message = "The adapter must retain the service-normalized disabled audit group."
+  }
 }
 
 run "role_assignment_name_is_preserved" {
   command = apply
 
   assert {
-    condition     = azurerm_role_assignment.this["reader"].name == "11111111-1111-1111-1111-111111111111"
-    error_message = "The AzureRM role assignment must use the utility module's retained UUID."
+    condition     = azapi_resource.role_assignments["reader"].name == "11111111-1111-1111-1111-111111111111"
+    error_message = "The AzAPI role assignment must use the utility module's retained UUID."
+  }
+}
+
+run "private_endpoint_payload_preserves_legacy_identity" {
+  command = plan
+
+  assert {
+    condition     = azapi_resource.private_endpoints["primary"].body.properties.customNetworkInterfaceName == "nic-test"
+    error_message = "The private endpoint must preserve an explicitly configured NIC name."
+  }
+
+  assert {
+    condition     = azapi_resource.private_endpoints["primary"].body.properties.applicationSecurityGroups[0].id == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationSecurityGroups/asg-test"
+    error_message = "The private endpoint payload must retain ASG associations."
+  }
+
+  assert {
+    condition     = azapi_resource.private_dns_zone_groups["primary"].body.properties.privateDnsZoneConfigs[0].name == "privatelink.eastus.azmk8s.io"
+    error_message = "The DNS zone configuration name must match the legacy Azure-generated name."
+  }
+}
+
+run "lock_notes_are_preserved" {
+  command = plan
+
+  assert {
+    condition     = azapi_resource.lock[0].body.properties.notes == "Cannot delete the resource or its child resources."
+    error_message = "The AzAPI lock must preserve the legacy default notes."
   }
 }

--- a/tests/unit/kube_proxy_config.tftest.hcl
+++ b/tests/unit/kube_proxy_config.tftest.hcl
@@ -1,5 +1,4 @@
 mock_provider "azapi" {}
-mock_provider "azurerm" {}
 mock_provider "modtm" {}
 mock_provider "random" {}
 

--- a/tests/unit/monitoring_names.tftest.hcl
+++ b/tests/unit/monitoring_names.tftest.hcl
@@ -1,5 +1,4 @@
 mock_provider "azapi" {}
-mock_provider "azurerm" {}
 mock_provider "modtm" {}
 mock_provider "random" {}
 
@@ -68,4 +67,3 @@ run "long_cluster_names_are_capped_for_monitoring_resources" {
     error_message = "The capped MSProm data collection endpoint name must not contain consecutive hyphens or end with a hyphen."
   }
 }
-

--- a/tests/unit/network_profile.tftest.hcl
+++ b/tests/unit/network_profile.tftest.hcl
@@ -1,5 +1,4 @@
 mock_provider "azapi" {}
-mock_provider "azurerm" {}
 mock_provider "modtm" {}
 mock_provider "random" {}
 

--- a/tests/unit/outputs.tftest.hcl
+++ b/tests/unit/outputs.tftest.hcl
@@ -17,7 +17,6 @@ mock_provider "azapi" {
     }
   }
 }
-mock_provider "azurerm" {}
 mock_provider "modtm" {}
 mock_provider "random" {}
 


### PR DESCRIPTION
## Summary

- replace the remaining lock, role assignment, diagnostic setting, and private endpoint AzureRM implementations with AzAPI resources backed by `Azure/avm-utl-interfaces/azure`
- remove the root module's AzureRM provider requirement
- move lock, role-assignment, and diagnostic-setting state where one-to-one moves are safe
- preserve legacy diagnostic semantics, including Azure's disabled `audit` group, lock notes, private endpoint names/NIC/connection/ASG identity, and DNS config names
- document required manual private endpoint and DNS child state adoption

Fixes #268

Stacked on #269; review this PR after the preparation PR.

## Live upgrade evidence

A real v0.7.1 AKS baseline in `northcentralus` used Free tier and one `Standard_D2as_v5` node with all four interfaces enabled. After applying the #269 preparation and adopting the existing role UUID, I removed only the legacy PE/ASG state and imported the same Azure PE and DNS child into their AzAPI addresses.

The breaking upgrade plan was `0 to add, 5 to change, 0 to destroy`; all five actions kept identical Azure resource IDs. Apply completed `0 added, 5 changed, 0 destroyed`. A subsequent plan reported no changes and `terraform providers` showed no AzureRM provider in either configuration or state.

Post-upgrade Azure checks showed the same AKS cluster succeeded, the same Reader assignment UUID, CanNotDelete lock, diagnostic destination/categories, approved PE connection, NIC, ASG association, and succeeded DNS child.

## Validation

- `PORCH_NO_TUI=1 ./avm tf-test-unit`: passed
- `PORCH_NO_TUI=1 ./avm pre-commit`: passed
- `PORCH_NO_TUI=1 ./avm pr-check`: passed
- final cleanup: 19 resources destroyed; Terraform state count 0; primary and AKS node resource groups absent

## Migration caveat

Terraform cannot move one legacy `azurerm_private_endpoint` state object to both the AzAPI endpoint and standalone DNS child. Users must follow `MIGRATION.md` to run non-destructive `state rm` and imports before planning. No speculative automatic move is included.